### PR TITLE
Address rsync/npm issue with incompatibility between OS X libsass and Ubuntu libsass.

### DIFF
--- a/.rsync-ignore
+++ b/.rsync-ignore
@@ -1,0 +1,6 @@
+node_modules
+.git
+.rsync-ignore
+Makefile
+README.rst
+.DS_Store

--- a/Makefile
+++ b/Makefile
@@ -2,4 +2,4 @@ up:
 	curl -o /usr/local/bin/docker-osx-dev https://raw.githubusercontent.com/brikis98/docker-osx-dev/master/src/docker-osx-dev
 	chmod +x /usr/local/bin/docker-osx-dev
 	docker-osx-dev install
-	docker-osx-dev -m default -s ./
+	docker-osx-dev -m default -s ./ --ignore-file '.rsync-ignore'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,9 @@ watch:
   image: teachersportal_web
   command: >
     /bin/bash -c '
+    npm cache clean &&
     npm install --production --no-bin-links &&
+    npm rebuild node-sass &&
     echo Finished npm install &&
     node ./node_modules/webpack-dev-server/bin/webpack-dev-server.js --content-base ./static --host 0.0.0.0 --port 8076 --progress --hot --inline'
   ports:


### PR DESCRIPTION
The docker-osx-dev rsync solution is a great workaround for the docker/osx/webpack non-syncing problem. But it needs to be tailored so that it doesn't sync OSX specific stuff, and node_modules and such to the docker container. This PR adds an ignore file for rsync, and updates the makefile to use that ignore file.
