### PR TITLE
Added react-devtools

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -13,7 +13,8 @@
   },
   "env": {
     "es6": true,
-    "browser": true
+    "browser": true,
+    "node": true
   },
   "ecmaFeatures": {
     "jsx": true

--- a/README.rst
+++ b/README.rst
@@ -35,6 +35,14 @@ docker-compose up, you would run: docker-osx-dev -m default -s ./
 (if your docker VM is called `default`, and your CWD is the
 root of the teachers portal source directory).
 
+Dev Tools
+=========
+
+`react-devtools <https://github.com/gaearon/redux-devtools>` is in use
+on this repository. This will help you debug actions and mutations to
+the underlying redux store. To enable it, press `Ctrl+H`. You can then
+click the action names to undo or redo them.
+
 
 Adding an application
 =====================

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,7 +27,7 @@ watch:
   command: >
     /bin/bash -c '
     npm cache clean &&
-    npm install --production --no-bin-links &&
+    npm install --no-bin-links &&
     npm rebuild node-sass &&
     echo Finished npm install &&
     node ./node_modules/webpack-dev-server/bin/webpack-dev-server.js --content-base ./static --host 0.0.0.0 --port 8076 --progress --hot --inline'

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "jsdom": "^7.0.2",
     "mocha": "^2.3.3",
     "mocha-jsdom": "^1.0.0",
-    "react-addons-test-utils": "^0.14.2"
+    "react-addons-test-utils": "^0.14.2",
+    "redux-devtools": "^2.1.5"
   },
   "dependencies": {
     "babel": "^6.0.15",

--- a/static/js/index_page.js
+++ b/static/js/index_page.js
@@ -6,13 +6,21 @@ import { Provider } from 'react-redux';
 import configureStore from './store/configureStore';
 import { Router, Route } from 'react-router';
 
+import { devTools, persistState } from 'redux-devtools';
+import { DevTools, DebugPanel, LogMonitor } from 'redux-devtools/lib/react';
+
 const store = configureStore();
 
 ReactDOM.render(
-  <Provider store={store}>
-    <Router>
-      <Route path="/" component={App}/>
-    </Router>
-  </Provider>,
+  <div>
+    <Provider store={store}>
+      <Router>
+        <Route path="/" component={App}/>
+      </Router>
+    </Provider>
+    <DebugPanel top right bottom>
+      <DevTools store={store} monitor={LogMonitor} visibleOnLoad={false}/>
+    </DebugPanel>
+  </div>,
   document.getElementById("container")
 );

--- a/static/js/store/configureStore.js
+++ b/static/js/store/configureStore.js
@@ -1,12 +1,17 @@
 /* global require:false, module:false */
-import { createStore, applyMiddleware } from 'redux';
+import { compose, createStore, applyMiddleware } from 'redux';
 import thunkMiddleware from 'redux-thunk';
 import createLogger from 'redux-logger';
 import rootReducer from '../reducers';
+import {persistState, devTools} from 'redux-devtools';
 
-const createStoreWithMiddleware = applyMiddleware(
-  thunkMiddleware,
-  createLogger()
+const createStoreWithMiddleware = compose(
+  applyMiddleware(
+    thunkMiddleware,
+    createLogger()
+  ),
+  devTools(),
+  persistState(window.location.href.match(/[?&]debug_session=([^&]+)\b/))
 )(createStore);
 
 export default function configureStore(initialState) {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -7,15 +7,12 @@ var NodeNeat = require("node-neat");
 module.exports = {
   context: __dirname,
   entry: {
-    index_page: './static/js/index_page'
+    'index_page': './static/js/index_page'
   },
   output: {
-      path: path.resolve('./static/bundles/'),
-      filename: "[name].js"
+    path: path.resolve('./static/bundles/'),
+    filename: "[name].js"
   },
-
-  plugins: [
-  ],
 
   module: {
     loaders: [


### PR DESCRIPTION
Now, you can press Ctrl-H to have a django-debug-toolbar-esque popup for
seeing mutations to the redux store. Clicking the titles will disable or
enable that action.

This uses a feature of webpack which transforms our source to replace constants like `__DEVTOOLS__` with true/false, such that we can enable or disable features at compile time. If you change one of these, you'll need to kill and restart your watcher (at least that's what it seems like locally).

See here for examples: https://github.com/gaearon/redux-devtools
