### PR TITLE
Fixed hop-by-hop headers error

### DIFF
--- a/portal/tests/test_ccxcon_api.py
+++ b/portal/tests/test_ccxcon_api.py
@@ -55,6 +55,21 @@ class TestCCXConAPI(TestCase):
         assert resp.content.decode('utf-8') == 'success'
         assert resp['response_header'] == 'response_header_value'
 
+    @requests_mock.mock()
+    def test_hop_by_hop(self, mock):
+        """Test that Keep-Alive and other hop-by-hop headers are filtered out"""
+
+        mock.get(
+            "{base}v1/end/point".format(base=FAKE_CCXCON_API),
+            text="success",
+            headers={"Connection": "Keep-Alive"}
+        )
+
+        resp = self.client.get("{base}v1/end/point".format(base=reverse("ccxcon-api")))
+        assert resp.status_code == 200
+        assert resp.content.decode('utf-8') == 'success'
+        assert 'Connection' not in resp
+
     def test_post(self):
         """
         Test that POST requests are rejected.

--- a/portal/views.py
+++ b/portal/views.py
@@ -5,6 +5,7 @@ Views for teachersportal.
 from __future__ import unicode_literals
 
 import json
+from wsgiref.util import is_hop_by_hop
 
 from django.conf import settings
 from django.shortcuts import render, HttpResponse
@@ -63,7 +64,8 @@ def forward_to_ccxcon(request):
     )
 
     for key, value in response.headers.items():
-        ccxcon_response[key] = value
+        if not is_hop_by_hop(key):
+            ccxcon_response[key] = value
 
     return ccxcon_response
 


### PR DESCRIPTION
Fixed #106 

Hop by hop headers are generally special headers like `Connection` and `Keep-Alive` which we don't have any need to mess with. There's a complete list here: http://stackoverflow.com/questions/26044167/allow-hop-by-hop-header-django
