### PR TITLE
Removed django-oscar-api

### DIFF
--- a/portal/urls.py
+++ b/portal/urls.py
@@ -4,14 +4,12 @@ URLs for portal
 from django.conf import settings
 from django.conf.urls import url, include
 from django.contrib import admin
-from oscarapi.app import application as oscar_api
 from oscar.app import application as oscar
 
 from portal.views import index_view, ccxcon_view, WebhooksCCXConView
 
 urlpatterns = [
     url(r'^admin/', include(admin.site.urls)),
-    url(r'^oscarapi/', include(oscar_api.urls)),
     url(r'^ccxcon/', ccxcon_view, name='ccxcon-api'),
     url(r'^api/v1/webhooks/ccxcon/$', WebhooksCCXConView.as_view(), name='webhooks-ccxcon'),
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,6 @@ psycopg2==2.6
 tox>=2.0.2,<3.0.0
 static3==0.6.1
 django-oscar==1.1.1
-git+https://github.com/mitodl/django-oscar-api.git@e7b61defd6d762e2b4c4fcc451040b056d36b26b#egg=django-oscar-api==0.0.36-odl
 requests==2.8.1
 pycountry==1.18
 djangorestframework==3.3.0


### PR DESCRIPTION
Fixes #114 

Instead we'll create our own product API (See #117)
