### PR TITLE
Added product API

### DIFF
--- a/portal/serializers.py
+++ b/portal/serializers.py
@@ -1,0 +1,22 @@
+"""
+Serializers for REST API
+"""
+
+from __future__ import unicode_literals
+
+from rest_framework.serializers import (
+    Serializer,
+    CharField,
+    DecimalField,
+)
+
+
+# pylint: disable=abstract-method
+class ProductSerializer(Serializer):
+    """Serializer for Product"""
+
+    title = CharField()
+    external_pk = CharField()
+    product_type = CharField()
+    price_without_tax = DecimalField(max_digits=20, decimal_places=2)
+    parent_external_pk = CharField()

--- a/portal/tests/test_product_api.py
+++ b/portal/tests/test_product_api.py
@@ -1,0 +1,403 @@
+"""
+Tests for Product API
+"""
+
+from __future__ import unicode_literals
+
+from django.test import TestCase
+from django.core.urlresolvers import reverse
+from oscar.apps.catalogue.models import Product, ProductClass
+from oscar.apps.partner.models import Partner, StockRecord
+
+from portal.tests.util import as_json
+from portal.util import (
+    make_external_pk,
+    make_upc,
+    COURSE_PRODUCT_TYPE,
+    MODULE_PRODUCT_TYPE,
+)
+
+
+class ProductAPITests(TestCase):
+    """
+    Tests for product API
+    """
+
+    def setUp(self):
+        """
+        Create parent and child Products with no StockRecords to start with.
+        """
+        product_class = ProductClass.objects.get(name="Course")
+        self.parent_external_pk = "uuid"
+        parent_upc = make_upc(COURSE_PRODUCT_TYPE, self.parent_external_pk)
+        parent_title = "parent's title"
+        self.parent = Product.objects.create(
+            upc=parent_upc,
+            product_class=product_class,
+            structure=Product.PARENT,
+            parent=None,
+            title=parent_title
+        )
+
+        self.child_external_pk = "uuid"
+        child_upc = make_upc(MODULE_PRODUCT_TYPE, self.child_external_pk)
+        child_title = "child's title"
+        self.child = Product.objects.create(
+            upc=child_upc,
+            product_class=None,
+            structure=Product.CHILD,
+            parent=self.parent,
+            title=child_title
+        )
+
+    def get_products(self):
+        """
+        Helper function to verify 200 and return list of products.
+        """
+        resp = self.client.get(reverse("product-list"))
+        assert resp.status_code == 200, resp.content
+        products_from_api = as_json(resp)
+
+        for product_from_api in products_from_api:
+            # Assert consistency between database and what API endpoint is returning.
+            product_from_db = Product.objects.get(
+                upc=make_upc(
+                    product_from_api['product_type'],
+                    product_from_api['external_pk']
+                )
+            )
+            assert product_from_db.title == product_from_api['title']
+            assert product_from_db.upc == make_upc(
+                product_from_api['product_type'],
+                product_from_api['external_pk'],
+            )
+
+            parent = product_from_db.parent
+            if parent is None:
+                assert product_from_api['parent_external_pk'] is None
+                if product_from_db.children.count() == 0:
+                    assert product_from_db.structure == Product.STANDALONE
+                else:
+                    assert product_from_db.structure == Product.PARENT
+
+                assert product_from_db.product_class == ProductClass.objects.get(name="Course")
+            else:
+                assert product_from_db.product_class is None
+                assert product_from_api['parent_external_pk'] == make_external_pk(
+                    str(parent.product_class),
+                    parent.upc
+                )
+                assert product_from_db.structure == Product.CHILD
+
+                # Make sure there's one StockRecord and SKU matches UPC
+                assert product_from_db.stockrecords.count() == 1
+                assert product_from_db.upc == product_from_db.stockrecords.first().partner_sku
+        return products_from_api
+
+    def test_no_stockrecord(self):
+        """
+        Make sure API shows no products if none have StockRecords.
+        """
+        assert self.get_products() == []
+
+    def test_one_stockrecord(self):
+        """
+        Make sure API returns this product since it has a StockRecord.
+        """
+        partner = Partner.objects.first()
+        StockRecord.objects.create(
+            product=self.child,
+            partner=partner,
+            partner_sku=self.child.upc,
+            price_currency="$",
+            price_excl_tax=123,
+        )
+
+        # API only shows products with StockRecords
+        assert self.get_products() == [
+            {
+                'external_pk': self.parent_external_pk,
+                'parent_external_pk': None,
+                'price_without_tax': None,
+                'product_type': COURSE_PRODUCT_TYPE,
+                'title': self.parent.title
+            },
+            {
+                'external_pk': self.child_external_pk,
+                'parent_external_pk': self.parent_external_pk,
+                'price_without_tax': '123.00',
+                'product_type': MODULE_PRODUCT_TYPE,
+                'title': self.child.title
+            },
+        ]
+
+    def test_parent_cant_have_price(self):
+        """
+        Make sure parent can't have a price.
+        """
+        partner = Partner.objects.first()
+        StockRecord.objects.create(
+            product=self.parent,
+            partner=partner,
+            partner_sku=self.parent.upc,
+            price_currency="$",
+            price_excl_tax=123,
+        )
+
+        with self.assertRaises(Exception) as ex:
+            self.get_products()
+        assert ex.exception.args[0] == "Only CHILD products can have StockRecords"
+
+    def test_invalid_partner_sku(self):
+        """
+        Access API when a StockRecord's partner_sku doesn't match Product.upc.
+        """
+        price = 123
+        partner = Partner.objects.first()
+        StockRecord.objects.create(
+            product=self.child,
+            partner=partner,
+            partner_sku=make_upc(MODULE_PRODUCT_TYPE, "mismatched sku"),
+            price_currency="$",
+            price_excl_tax=price,
+        )
+
+        with self.assertRaises(Exception) as ex:
+            self.get_products()
+        assert ex.exception.args[0] == "StockRecord SKU does not match Product UPC"
+
+    def test_invalid_currency(self):
+        """
+        Make sure currency == "$".
+        """
+        price = 123
+        partner = Partner.objects.first()
+        StockRecord.objects.create(
+            product=self.child,
+            partner=partner,
+            partner_sku=self.child.upc,
+            price_currency="GBP",
+            price_excl_tax=price,
+        )
+
+        with self.assertRaises(Exception) as ex:
+            self.get_products()
+        assert ex.exception.args[0] == "StockRecord price_currency must be $"
+
+    def test_two_stockrecords(self):
+        """
+        Try creating a product with two StockRecords.
+        """
+        other_sku = make_upc(MODULE_PRODUCT_TYPE, "other sku")
+
+        price1, price2 = 123, 345
+        partner = Partner.objects.first()
+        StockRecord.objects.create(
+            product=self.child,
+            partner=partner,
+            partner_sku=other_sku,
+            price_currency="$",
+            price_excl_tax=price1,
+        )
+        StockRecord.objects.create(
+            product=self.child,
+            partner=partner,
+            partner_sku=self.child.upc,
+            price_currency="$",
+            price_excl_tax=price2,
+        )
+
+        with self.assertRaises(Exception) as ex:
+            self.get_products()
+        assert ex.exception.args[0] == "More than one StockRecords for a Product"
+
+    def test_child_without_parent(self):
+        """
+        Children must have parents.
+        """
+        with self.assertRaises(AttributeError) as ex:
+            Product.objects.create(
+                upc=make_upc(MODULE_PRODUCT_TYPE, "child"),
+                product_class=None,
+                structure=Product.CHILD,
+                parent=None,
+                title=self.child.title
+            )
+        assert ex.exception.args[0] == "'NoneType' object has no attribute 'product_class'"
+
+    def test_child_has_no_children(self):
+        """
+        Children must not have children.
+        """
+        child = Product.objects.create(
+            upc=make_upc(MODULE_PRODUCT_TYPE, "parent child"),
+            product_class=self.parent.product_class,
+            structure=Product.CHILD,
+            parent=self.parent,
+            title="child of parent"
+        )
+        Product.objects.create(
+            upc=make_upc(MODULE_PRODUCT_TYPE, "child"),
+            product_class=self.parent.product_class,
+            structure=Product.CHILD,
+            parent=child,
+            title="child of child"
+        )
+        with self.assertRaises(Exception) as ex:
+            self.get_products()
+        assert ex.exception.args[0] == "Children cannot have product_class set"
+
+    def test_parent_has_children(self):
+        """
+        Parents must have children.
+        """
+        Product.objects.create(
+            upc=make_upc(COURSE_PRODUCT_TYPE, "parent"),
+            product_class=self.parent.product_class,
+            structure=Product.PARENT,
+            parent=None,
+            title=self.parent.title
+        )
+        with self.assertRaises(Exception) as ex:
+            self.get_products()
+        assert ex.exception.args[0] == "PARENT products must have children"
+
+    def test_standalone_has_no_children(self):
+        """
+        Standalone products must not have children.
+        """
+        parent = Product.objects.create(
+            upc=make_upc(COURSE_PRODUCT_TYPE, "parent"),
+            product_class=self.parent.product_class,
+            structure=Product.STANDALONE,
+            parent=None,
+            title=self.parent.title
+        )
+        Product.objects.create(
+            upc=make_upc(MODULE_PRODUCT_TYPE, "child"),
+            product_class=self.parent.product_class,
+            structure=Product.CHILD,
+            parent=parent,
+            title="child"
+        )
+        with self.assertRaises(Exception) as ex:
+            self.get_products()
+        assert ex.exception.args[0] == "STANDALONE products must not have children"
+
+    def test_parent_with_parent(self):
+        """
+        Parents must not have a parent.
+        """
+        Product.objects.create(
+            upc=make_upc(COURSE_PRODUCT_TYPE, "parent"),
+            product_class=self.parent.product_class,
+            structure=Product.PARENT,
+            parent=self.parent,
+            title=self.parent.title
+        )
+        with self.assertRaises(Exception) as ex:
+            self.get_products()
+        assert ex.exception.args[0] == "PARENT products must not have a parent"
+
+    def test_child_is_not_module(self):
+        """
+        Only modules can be children.
+        """
+        Product.objects.create(
+            upc=make_upc(COURSE_PRODUCT_TYPE, "child"),
+            product_class=None,
+            structure=Product.CHILD,
+            parent=self.parent,
+            title=self.child.title
+        )
+        with self.assertRaises(Exception) as ex:
+            self.get_products()
+        assert ex.exception.args[0] == "Modules may only be CHILD Products"
+
+    def test_parent_is_not_course(self):
+        """
+        Only courses can be parents.
+        """
+        Product.objects.create(
+            upc=make_upc(MODULE_PRODUCT_TYPE, "child"),
+            product_class=self.parent.product_class,
+            structure=Product.PARENT,
+            parent=None,
+            title=self.parent.title
+        )
+        with self.assertRaises(Exception) as ex:
+            self.get_products()
+        assert ex.exception.args[0] == "Courses may only be PARENT Products"
+
+    def test_standalone_is_not_course(self):
+        """
+        Only courses can be standalone.
+        """
+        Product.objects.create(
+            upc=make_upc(MODULE_PRODUCT_TYPE, "child"),
+            product_class=self.parent.product_class,
+            structure=Product.STANDALONE,
+            parent=None,
+            title=self.parent.title
+        )
+        with self.assertRaises(Exception) as ex:
+            self.get_products()
+        assert ex.exception.args[0] == "Courses may only be PARENT Products"
+
+    def test_invalid_upc(self):
+        """
+        UPC must be prefixed with product type
+        """
+        Product.objects.create(
+            upc=make_upc("other", "child"),
+            product_class=None,
+            structure=Product.CHILD,
+            parent=self.parent,
+            title=self.child.title
+        )
+        with self.assertRaises(Exception) as ex:
+            self.get_products()
+        assert ex.exception.args[0] == "Invalid product type"
+
+    def test_child_with_product_class(self):
+        """
+        Children can't have product_class set (it inherits from parent)
+        """
+        Product.objects.create(
+            upc=make_upc(MODULE_PRODUCT_TYPE, "child"),
+            product_class=self.parent.product_class,
+            structure=Product.CHILD,
+            parent=self.parent,
+            title=self.child.title
+        )
+        with self.assertRaises(Exception) as ex:
+            self.get_products()
+        assert ex.exception.args[0] == "Children cannot have product_class set"
+
+    def test_parent_product_class(self):
+        """
+        Parent product class must be set to Course.
+        """
+        with self.assertRaises(AttributeError) as ex:
+            Product.objects.create(
+                upc=make_upc(COURSE_PRODUCT_TYPE, "parent"),
+                product_class=None,
+                structure=Product.PARENT,
+                parent=None,
+                title=self.parent.title
+            )
+        assert ex.exception.args[0] == "'NoneType' object has no attribute 'attributes'"
+
+    def test_standalone_product_class(self):
+        """
+        Standalone product class must be set to Course.
+        """
+        with self.assertRaises(AttributeError) as ex:
+            Product.objects.create(
+                upc=make_upc(COURSE_PRODUCT_TYPE, "parent"),
+                product_class=None,
+                structure=Product.STANDALONE,
+                parent=None,
+                title=self.parent.title
+            )
+        assert ex.exception.args[0] == "'NoneType' object has no attribute 'attributes'"

--- a/portal/tests/util.py
+++ b/portal/tests/util.py
@@ -1,0 +1,19 @@
+"""
+Utility functions for tests
+"""
+
+from __future__ import unicode_literals
+import json
+
+
+def as_json(resp):
+    """
+
+    Args:
+        resp (HttpResponse): Response
+
+    Returns:
+        any: An object created from JSON in response.
+    """
+    assert resp.status_code == 200
+    return json.loads(resp.content.decode('utf-8'))

--- a/portal/urls.py
+++ b/portal/urls.py
@@ -12,6 +12,7 @@ from portal.views import (
     WebhooksCCXConView,
     LoginView,
     logout_view,
+    ProductListView,
 )
 
 urlpatterns = [
@@ -20,6 +21,7 @@ urlpatterns = [
     url(r'^api/v1/webhooks/ccxcon/$', WebhooksCCXConView.as_view(), name='webhooks-ccxcon'),
     url(r'^api/v1/login/$', LoginView.as_view(), name='login'),
     url(r'^api/v1/logout/$', logout_view, name='logout'),
+    url(r'^api/v1/products/$', ProductListView.as_view(), name='product-list'),
 ]
 
 if settings.PORTAL_OSCAR_VISIBLE:

--- a/portal/util.py
+++ b/portal/util.py
@@ -4,6 +4,13 @@ Helper functions which may be generally useful.
 
 from __future__ import unicode_literals
 
+from oscar.apps.catalogue.models import Product
+from oscar.apps.partner.strategy import Selector
+
+
+MODULE_PRODUCT_TYPE = "Module"
+COURSE_PRODUCT_TYPE = "Course"
+
 
 def make_upc(product_type, external_pk):
     """
@@ -11,10 +18,175 @@ def make_upc(product_type, external_pk):
 
     Args:
         product_type (basestring):
-            The name of the ProductClass associated with the Product.
+            The name of the product type.
         external_pk (basestring):
             An identifer string, unique within the ProductClass.
     Returns:
         basestring: A unique string id.
     """
     return "{type}_{pk}".format(type=product_type, pk=external_pk)
+
+
+def make_external_pk(product_type, upc):
+    """
+    We concatenate the product class with the UUID to store it in Product.upc
+    which requires each entry to be unique (the incoming UUIDs are only guaranteed
+    to be unique within product class). This chops off the product class and returns
+    the UUID to be exposed via REST API.
+
+    Args:
+        product_type (basestring):
+            The name of the product type.
+        upc (basestring):
+            The UPC used inside the database.
+    Returns:
+        basestring: The external_pk value used in creating this UUID
+    """
+    prefix = "{product_type}_".format(product_type=product_type)
+    if upc.startswith(prefix):
+        return upc[len(prefix):]
+
+    # Should never happen since only the webhooks should update this listing
+    raise Exception("Unexpected prefix found")
+
+
+def get_external_pk(product):
+    """
+    Helper function to get external_pk for a product which may be None.
+
+    Args:
+        product (oscar.apps.catalogue.models.Product):
+            A Product (may be None)
+    Returns:
+        basestring: The appropriate external pk for the Product, or None if
+        product is None.
+    """
+    if product is None:
+        return None
+    if product.structure == Product.PARENT or product.structure == Product.STANDALONE:
+        product_type = COURSE_PRODUCT_TYPE
+    elif product.structure == Product.CHILD:
+        product_type = MODULE_PRODUCT_TYPE
+    else:
+        raise Exception("Unexpected structure")
+    return make_external_pk(product_type, product.upc)
+
+
+def get_product_type(product):
+    """
+    Parse product type from UPC.
+
+    Args:
+        product (oscar.apps.catalogue.models.Product):
+            A Product
+    Returns:
+        basestring: The product type
+    """
+    upc = product.upc
+    for product_type in (COURSE_PRODUCT_TYPE, MODULE_PRODUCT_TYPE):
+        if upc.startswith("{product_type}_".format(product_type=product_type)):
+            return product_type
+    raise Exception("Invalid product type")
+
+
+# pylint: disable=too-many-branches
+def validate_product(product):
+    """
+    Raise an exception if the product is invalid in some way, based on the rules
+    we are enforcing in this app. (This may raise Exceptions for things that
+    are valid by django-oscar.)
+    """
+    # This is not the same as the product type which is part of the UPC.
+    if product.structure == Product.CHILD:
+        if product.product_class is not None:
+            raise Exception("Children cannot have product_class set")
+        if product.parent is None:
+            raise Exception("CHILD products must have a parent")
+        if product.children.count() != 0:
+            raise Exception("CHILD products must not have children")
+        if get_product_type(product) != MODULE_PRODUCT_TYPE:
+            raise Exception("Modules may only be CHILD Products")
+    elif product.structure == Product.PARENT or product.structure == Product.STANDALONE:
+        if product.product_class.name != "Course":
+            raise Exception("Only Course ProductClass may be set")
+        if product.parent is not None:
+            raise Exception("PARENT products must not have a parent")
+        if get_product_type(product) != COURSE_PRODUCT_TYPE:
+            raise Exception("Courses may only be PARENT Products")
+        if product.structure == Product.PARENT and product.children.count() == 0:
+            raise Exception("PARENT products must have children")
+        if product.structure == Product.STANDALONE and product.children.count() > 0:
+            raise Exception("STANDALONE products must not have children")
+
+    stockrecords = product.stockrecords.all()
+    if stockrecords.count() > 0:
+        if product.structure != Product.CHILD:
+            raise Exception("Only CHILD products can have StockRecords")
+        if stockrecords.count() > 1:
+            raise Exception("More than one StockRecords for a Product")
+
+        stockrecord = stockrecords.first()
+        if stockrecord.partner_sku != product.upc:
+            raise Exception("StockRecord SKU does not match Product UPC")
+
+        if stockrecord.price_currency != "$":
+            raise Exception("StockRecord price_currency must be $")
+
+
+def get_price_without_tax(product):
+    """
+    Helper function to get price from Product's StockRecord.
+
+    Args:
+        product (oscar.apps.catalogue.models.Product):
+            A Product (may be None)
+    Returns:
+        decimal.Decimal: If product exists and has a price, return the price
+        else return None.
+    """
+    validate_product(product)
+
+    stockrecord = product.stockrecords.first()
+    if stockrecord is None:
+        # No price information, not available to buy
+        return None
+
+    # Get default strategy
+    strategy = Selector().strategy()
+    info = strategy.fetch_for_product(product, stockrecord)
+    return info.price.excl_tax
+
+
+def is_available_to_buy(product):
+    """
+    Is a Product available to purchase? For our purposes this means if it has
+    a price set.
+
+    Args:
+        product (oscar.apps.catalogue.models.Product):
+            A Product
+    Returns:
+        bool: True if product is available to buy
+    """
+    validate_product(product)
+
+    if product.structure == Product.PARENT:
+        # Product will be available if any children are available
+        return any(
+            child for child in product.children.all()
+            if is_available_to_buy(child)
+        )
+    elif product.structure == Product.STANDALONE:
+        return False
+    elif product.structure == Product.CHILD:
+        stockrecord = product.stockrecords.first()
+        if stockrecord is None:
+            # No price information, not available to buy
+            return False
+
+        # Get default strategy
+        strategy = Selector().strategy()
+        info = strategy.fetch_for_product(product, stockrecord)
+        return info.availability.is_available_to_buy
+    else:
+        raise Exception("Unexpected structure")


### PR DESCRIPTION
#### What's this PR do?

Adds a read-only endpoint at `/api/v1/products/` to list all products in oscar database.
#### Where should the reviewer start?

`portal/views.py`
#### How should this be manually tested?

Add a product to the database:
- Start teacher's portal locally and go to http://localhost:8075/oscar/dashboard/catalogue/
- Under 'Create new product of type' choose 'Course' and click the plus next to it
- Put anything you want for title. UPC **must** begin with `Course_` but otherwise can be anything
- On the left click 'Categories' and then select 'Course' which should be the only category available
- Click 'Save and continue editing'
- On the left click 'Variants', then click 'Add variant'
- Fill in whatever title you want. The UPC **must** start with `Module_` but otherwise can be anything
- On the left click 'Stock and Pricing'. Partner should be edX (the only partner which should be available). SKU _must_ be exactly the same as the value you put in the UPC text field (the one that began with `Module_`). Currency should be `$`. Enter a number for "Price (excl tax)" (make sure it's not "Cost price" or something else). Click Save.
- Go to `/api/v1/products/` and verify that you see two products, the course and then the module. It must be at the end of the list since this list should be sorted by creation order.
#### Any background context you want to provide?

This doesn't include a detail page as it doesn't seem necessary right now.
#### What are the relevant tickets?

Fixes #117 
#### What gif best describes this PR or how it makes you feel?

![](https://media4.giphy.com/media/3o85xo8f9wVYcwzZcY/200.gif)
