### PR TITLE
Allow HTML in AboutTab, add CourseImage Component

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,8 @@
     "bourbon-neat": "^1.7.2",
     "css-loader": "^0.22.0",
     "es6-promise": "^3.0.2",
+    "history": "~1.13.1",
+    "isomorphic-fetch": "~2.2.0",
     "jsx-loader": "^0.13.2",
     "material-ui": "^0.13.2",
     "node-neat": "^1.7.2",
@@ -33,22 +35,20 @@
     "react-addons": "^0.9.1-deprecated",
     "react-dom": "^0.14.2",
     "react-redux": "^4.0.0",
+    "react-router": "~1.0.0",
+    "react-tap-event-plugin": "^0.2.1",
     "redux": "^3.0.4",
+    "redux-devtools": "^2.1.5",
+    "redux-logger": "~2.0.4",
+    "redux-thunk": "~1.0.0",
     "sass-loader": "^3.1.1",
     "style-loader": "^0.13.0",
     "webpack": "^1.12.3",
     "webpack-bundle-tracker": "0.0.8",
     "webpack-dev-server": "^1.12.1",
-    "webpack-stats-plugin": "^0.1.1",
-    "history": "~1.13.1",
-    "react-router": "~1.0.0",
-    "isomorphic-fetch": "~2.2.0",
-    "redux-thunk": "~1.0.0",
-    "redux-logger": "~2.0.4",
-    "react-tap-event-plugin": "^0.2.1",
-    "redux-devtools": "^2.1.5"
+    "webpack-stats-plugin": "^0.1.1"
   },
-    "scripts": {
+  "scripts": {
     "postinstall": "node node_modules/webpack/bin/webpack.js"
   }
 }

--- a/static/js/components/AboutTab.js
+++ b/static/js/components/AboutTab.js
@@ -1,13 +1,10 @@
 import React from 'react';
-import Lorem from './Lorem';
 
 class AboutTab extends React.Component {
   render() {
     const { content } = this.props;
 
-    return <div id="course-about-tab">
-        { content }
-    </div>;
+    return <div id="course-about-tab" dangerouslySetInnerHTML={{__html: content }}></div>;
   }
 }
 

--- a/static/js/components/CourseDetail.js
+++ b/static/js/components/CourseDetail.js
@@ -4,16 +4,14 @@ import { connect } from 'react-redux';
 import Card from 'material-ui/lib/card/card';
 import CardText from 'material-ui/lib/card/card-text';
 import CourseTabs from './CourseTabs';
+import CourseImage from './CourseImage';
 import CardActions from 'material-ui/lib/card/card-actions';
 import CardExpandable from 'material-ui/lib/card/card-expandable';
 import CardHeader from 'material-ui/lib/card/card-header';
 import CardMedia from 'material-ui/lib/card/card-media';
 import CardTitle from 'material-ui/lib/card/card-title';
-import Lorem from './Lorem';
-import { fetchCourses } from '../actions/index_page';
 
 class CourseDetail extends Component {
-
     render() {
       const { course, modules, error } = this.props;
 
@@ -22,11 +20,6 @@ class CourseDetail extends Component {
       if (error !== undefined) {
         content = <CardText>{error}</CardText>;
       } else {
-        let courseImageUrl = "http://lorempixel.com/g/350/250/abstract";
-
-        if (course.image_url) {
-          courseImageUrl = course.image_url;
-        }
 
         content = <div>
           <CardTitle
@@ -34,11 +27,7 @@ class CourseDetail extends Component {
             subtitle={course.author}
             id="course-title"
           />
-          <Card id="course-image">
-              <CardMedia>
-                <img src={courseImageUrl} alt="Course detail image"/>
-              </CardMedia>
-          </Card>
+          <CourseImage src={course.image_url} />
           <CardText id="course-description">
               {course.description}
           </CardText>

--- a/static/js/components/CourseImage.js
+++ b/static/js/components/CourseImage.js
@@ -1,0 +1,21 @@
+import React, { Component, PropTypes } from 'react';
+import Card from 'material-ui/lib/card/card';
+import CardMedia from 'material-ui/lib/card/card-media';
+
+class CourseImage extends Component {
+  render() {
+    const { imageUrl } = this.props;
+    let loremImage = "http://lorempixel.com/g/350/250/abstract";
+
+    // TODO: When we're pointing at real images, use those.
+    let image = loremImage;
+
+    return <Card id="course-image">
+      <CardMedia>
+        <img src={image} alt="Course detail image"/>
+      </CardMedia>
+    </Card>;
+  }
+}
+
+export default CourseImage;


### PR DESCRIPTION
For discussion. This allows HTML set in the course description to show in the TP Course Detail About Tab. Doesn't sanitize it at all. We should probably discuss the wisdom of that. Even an unclosed div might have unsightly consequences, to say nothing of malicious js or ugly markup/styles.
