### PR TITLE
Cast resp.content to string on assertion.

### DIFF
--- a/portal/views/activation_test.py
+++ b/portal/views/activation_test.py
@@ -26,7 +26,7 @@ class ActivationTests(AuthenticationTestCase):
             }),
             content_type="application/json"
         )
-        assert resp.status_code == 200, resp.content
+        assert resp.status_code == 200, resp.content.decode('utf-8')
         self.inactive_user.refresh_from_db()
         assert self.inactive_user.is_active
         # User is not logged in automatically just by clicking the link
@@ -45,7 +45,7 @@ class ActivationTests(AuthenticationTestCase):
             }),
             content_type="application/json"
         )
-        assert resp.status_code == 200, resp.content
+        assert resp.status_code == 200, resp.content.decode('utf-8')
         assert self.user.is_active
         assert not self.is_authenticated(self.user)
 
@@ -62,7 +62,7 @@ class ActivationTests(AuthenticationTestCase):
             }),
             content_type="application/json"
         )
-        assert resp.status_code == 403, resp.content
+        assert resp.status_code == 403, resp.content.decode('utf-8')
 
     def test_invalid_json(self):
         """
@@ -73,7 +73,7 @@ class ActivationTests(AuthenticationTestCase):
             "{",
             content_type="application/json"
         )
-        assert resp.status_code == 400, resp.content
+        assert resp.status_code == 400, resp.content.decode('utf-8')
         assert "JSON parse error" in resp.content.decode('utf-8')
 
     def test_missing_token(self):
@@ -86,7 +86,7 @@ class ActivationTests(AuthenticationTestCase):
             }),
             content_type="application/json"
         )
-        assert resp.status_code == 400, resp.content
+        assert resp.status_code == 400, resp.content.decode('utf-8')
         assert "Missing key token" in resp.content.decode('utf-8')
 
     def test_empty_token(self):
@@ -101,5 +101,5 @@ class ActivationTests(AuthenticationTestCase):
             }),
             content_type="application/json"
         )
-        assert resp.status_code == 400, resp.content
+        assert resp.status_code == 400, resp.content.decode('utf-8')
         assert "token is empty" in resp.content.decode('utf-8')

--- a/portal/views/login_test.py
+++ b/portal/views/login_test.py
@@ -32,7 +32,7 @@ class LoginTests(AuthenticationTestCase):
             }),
             content_type="application/json"
         )
-        assert resp.status_code == 200, resp.content
+        assert resp.status_code == 200, resp.content.decode('utf-8')
         assert self.is_authenticated(self.user)
         assert not self.is_authenticated(self.other_user)
 
@@ -48,7 +48,7 @@ class LoginTests(AuthenticationTestCase):
             }),
             content_type="application/json"
         )
-        assert resp.status_code == 403, resp.content
+        assert resp.status_code == 403, resp.content.decode('utf-8')
         assert not self.is_authenticated(self.user)
 
     def test_login_with_bad_username(self):
@@ -63,7 +63,7 @@ class LoginTests(AuthenticationTestCase):
             }),
             content_type="application/json"
         )
-        assert resp.status_code == 403, resp.content
+        assert resp.status_code == 403, resp.content.decode('utf-8')
         assert not self.is_authenticated(self.user)
 
     def test_login_missing_username(self):
@@ -77,7 +77,7 @@ class LoginTests(AuthenticationTestCase):
             }),
             content_type="application/json"
         )
-        assert resp.status_code == 400, resp.content
+        assert resp.status_code == 400, resp.content.decode('utf-8')
         assert not self.is_authenticated(self.user)
 
     def test_login_missing_password(self):
@@ -91,7 +91,7 @@ class LoginTests(AuthenticationTestCase):
             }),
             content_type="application/json"
         )
-        assert resp.status_code == 400, resp.content
+        assert resp.status_code == 400, resp.content.decode('utf-8')
         assert not self.is_authenticated(self.user)
 
     def test_login_not_an_object(self):
@@ -103,7 +103,7 @@ class LoginTests(AuthenticationTestCase):
             "{",
             content_type="application/json"
         )
-        assert resp.status_code == 400, resp.content
+        assert resp.status_code == 400, resp.content.decode('utf-8')
         assert not self.is_authenticated(self.user)
 
     def test_logout(self):
@@ -119,13 +119,13 @@ class LoginTests(AuthenticationTestCase):
             }),
             content_type="application/json"
         )
-        assert resp.status_code == 200, resp.content
+        assert resp.status_code == 200, resp.content.decode('utf-8')
         assert self.is_authenticated(self.user)
         assert not self.is_authenticated(self.other_user)
 
         # Now logout the logged in user.
         resp = self.client.post(reverse('logout'))
-        assert resp.status_code == 200, resp.content
+        assert resp.status_code == 200, resp.content.decode('utf-8')
         assert not self.is_authenticated(self.user)
         assert not self.is_authenticated(self.other_user)
 
@@ -135,6 +135,6 @@ class LoginTests(AuthenticationTestCase):
         and return a 200.
         """
         resp = self.client.post(reverse('logout'))
-        assert resp.status_code == 200, resp.content
+        assert resp.status_code == 200, resp.content.decode('utf-8')
         assert not self.is_authenticated(self.user)
         assert not self.is_authenticated(self.other_user)

--- a/portal/views/product_api_test.py
+++ b/portal/views/product_api_test.py
@@ -89,7 +89,7 @@ class ProductAPITests(ProductTests):
         StockRecord.objects.all().delete()
 
         resp = self.client.get(reverse("product-list"))
-        assert resp.status_code == 200, resp.content
+        assert resp.status_code == 200, resp.content.decode('utf-8')
         products_from_api = as_json(resp)
 
         self.validate_product_api(products_from_api)
@@ -101,7 +101,7 @@ class ProductAPITests(ProductTests):
         """
         # API only shows products with StockRecords
         resp = self.client.get(reverse("product-list"))
-        assert resp.status_code == 200, resp.content
+        assert resp.status_code == 200, resp.content.decode('utf-8')
         products_from_api = as_json(resp)
 
         self.validate_product_api(products_from_api)
@@ -245,7 +245,7 @@ class ProductAPITests(ProductTests):
         resp = self.client.get(
             reverse("product-detail", kwargs={"uuid": self.child.upc})
         )
-        assert resp.status_code == 404, resp.content
+        assert resp.status_code == 404, resp.content.decode('utf-8')
 
     def test_not_logged_in(self):
         """
@@ -255,10 +255,10 @@ class ProductAPITests(ProductTests):
         resp = self.client.get(
             reverse("product-detail", kwargs={"uuid": self.child.upc})
         )
-        assert resp.status_code == 403, resp.content
+        assert resp.status_code == 403, resp.content.decode('utf-8')
 
         resp = self.client.get(reverse("product-list"))
-        assert resp.status_code == 403, resp.content
+        assert resp.status_code == 403, resp.content.decode('utf-8')
 
     @patch('requests_oauthlib.oauth2_session.OAuth2Session.fetch_token', autospec=True)
     @requests_mock.mock()

--- a/portal/views/registration_test.py
+++ b/portal/views/registration_test.py
@@ -39,7 +39,7 @@ class RegistrationTests(AuthenticationTestCase):
             }),
             content_type="application/json"
         )
-        assert resp.status_code == 200, resp.content
+        assert resp.status_code == 200, resp.content.decode('utf-8')
         assert resp.content.decode('utf-8') == ""
 
         user = User.objects.get(email=email)
@@ -76,7 +76,7 @@ class RegistrationTests(AuthenticationTestCase):
                 json.dumps(data),
                 content_type="application/json"
             )
-            assert resp.status_code == 400, resp.content
+            assert resp.status_code == 400, resp.content.decode('utf-8')
             assert "Missing key {key}".format(key=key) in resp.content.decode('utf-8')
 
     def test_empty_key(self):
@@ -97,7 +97,7 @@ class RegistrationTests(AuthenticationTestCase):
                 json.dumps(data),
                 content_type="application/json"
             )
-            assert resp.status_code == 400, resp.content
+            assert resp.status_code == 400, resp.content.decode('utf-8')
             assert "Empty value for {key}".format(key=key) in resp.content.decode('utf-8')
 
     def test_invalid_data(self):
@@ -109,7 +109,7 @@ class RegistrationTests(AuthenticationTestCase):
             "{",
             content_type="application/json"
         )
-        assert resp.status_code == 400, resp.content
+        assert resp.status_code == 400, resp.content.decode('utf-8')
         assert "JSON parse error" in resp.content.decode('utf-8')
 
     def test_duplicate_email(self):
@@ -128,7 +128,7 @@ class RegistrationTests(AuthenticationTestCase):
             }),
             content_type="application/json"
         )
-        assert resp.status_code == 200, resp.content
+        assert resp.status_code == 200, resp.content.decode('utf-8')
 
         resp = self.client.post(
             reverse('register'),
@@ -141,7 +141,7 @@ class RegistrationTests(AuthenticationTestCase):
             }),
             content_type="application/json"
         )
-        assert resp.status_code == 400, resp.content
+        assert resp.status_code == 400, resp.content.decode('utf-8')
         assert "Email testuser@mit.edu is already in use" in resp.content.decode('utf-8')
 
     def test_user_already_exists(self):
@@ -166,7 +166,7 @@ class RegistrationTests(AuthenticationTestCase):
             }),
             content_type="application/json"
         )
-        assert resp.status_code == 400, resp.content
+        assert resp.status_code == 400, resp.content.decode('utf-8')
         assert "Email testuser@mit.edu is already in use" in resp.content.decode('utf-8')
 
     def test_user_logged_in(self):
@@ -193,4 +193,4 @@ class RegistrationTests(AuthenticationTestCase):
             }),
             content_type="application/json"
         )
-        assert resp.status_code == 403, resp.content
+        assert resp.status_code == 403, resp.content.decode('utf-8')

--- a/portal/views/webhooks_test.py
+++ b/portal/views/webhooks_test.py
@@ -80,7 +80,7 @@ class WebhookTests(TestCase):
 
         # Only products marked is_available should show up in this list
         resp = self.client.get(reverse("product-list"))
-        assert resp.status_code == 200, resp.content
+        assert resp.status_code == 200, resp.content.decode('utf-8')
         old_available = [product['external_pk'] for product in as_json(resp)]
 
         old_products = self.get_products()
@@ -90,7 +90,7 @@ class WebhookTests(TestCase):
             content_type="application/json",
             HTTP_X_CCXCON_SIGNATURE=signature
         )
-        assert resp.status_code == expected_status, resp.content
+        assert resp.status_code == expected_status, resp.content.decode('utf-8')
 
         product_api_resp = self.client.get(reverse("product-list"))
         assert product_api_resp.status_code == 200, product_api_resp.content
@@ -134,7 +134,7 @@ class WebhookTests(TestCase):
             data=json.dumps(data),
             content_type="application/json"
         )
-        assert resp.status_code == 403, resp.content
+        assert resp.status_code == 403, resp.content.decode('utf-8')
         assert "You do not have permission to perform this action." in resp.content.decode('utf-8')
 
     def test_webhook_with_bad_auth(self):
@@ -160,7 +160,7 @@ class WebhookTests(TestCase):
             content_type="application/json",
             HTTP_X_CCXCON_SIGNATURE=signature
         )
-        assert resp.status_code == 403, resp.content
+        assert resp.status_code == 403, resp.content.decode('utf-8')
         assert "You do not have permission to perform this action." in resp.content.decode('utf-8')
 
     def test_add_course(self):


### PR DESCRIPTION
This prevents unparsable errors such as https://travis-ci.com/mitodl/teachersportal/builds/19470354
