### PR TITLE
Add logging around product not available.

### DIFF
--- a/portal/util.py
+++ b/portal/util.py
@@ -3,6 +3,7 @@ Helper functions which may be generally useful.
 """
 
 from __future__ import unicode_literals
+import logging
 
 from rest_framework.exceptions import ValidationError
 from oscar.apps.catalogue.models import Product
@@ -12,6 +13,7 @@ from portal.models import Order, OrderLine
 
 MODULE_PRODUCT_TYPE = "Module"
 COURSE_PRODUCT_TYPE = "Course"
+log = logging.getLogger(__name__)
 
 
 def make_upc(product_type, external_pk):
@@ -174,16 +176,21 @@ def is_available_to_buy(product):
 
     if product.structure == Product.PARENT:
         # Product will be available if any children are available
-        return any(
+        has_available_children = any(
             child for child in product.children.all()
             if is_available_to_buy(child)
         )
+        if not has_available_children:
+            log.debug("Product %s doesn't have available children", product)
+        return has_available_children
     elif product.structure == Product.STANDALONE:
+        log.debug("Product %s is standalone.", product)
         return False
     elif product.structure == Product.CHILD:
         stockrecord = product.stockrecords.first()
         if stockrecord is None:
             # No price information, not available to buy
+            log.debug("Module %s doesn't have price information.", product)
             return False
 
         # Get default strategy

--- a/portal/views/product_api.py
+++ b/portal/views/product_api.py
@@ -3,6 +3,7 @@ Views for product availability listing.
 """
 from __future__ import unicode_literals
 
+import logging
 import json
 from six.moves.urllib.parse import urlparse, urlunparse  # pylint: disable=import-error
 
@@ -24,6 +25,9 @@ from portal.util import (
     COURSE_PRODUCT_TYPE,
     MODULE_PRODUCT_TYPE,
 )
+
+
+log = logging.getLogger(__name__)
 
 
 def fetch_ccxcon_info(product):
@@ -138,9 +142,11 @@ class ProductDetailView(RetrieveAPIView):
                 upc=product_uuid
             )
         except Product.DoesNotExist:
+            log.debug("Couldn't find a product with uuid %s in the portal", product_uuid)
             raise Http404
 
         if not is_available_to_buy(product):
+            log.debug("Product %s isn't available for sale.", product)
             raise Http404
 
         info = fetch_ccxcon_info(product)


### PR DESCRIPTION
This will help us determine why we're getting a 404 when requesting a
course detail page.
