### PR TITLE
Filtered out products from cart which aren't accessible in the API anymore

### DIFF
--- a/static/js/actions/index_page.js
+++ b/static/js/actions/index_page.js
@@ -29,6 +29,7 @@ export const UPDATE_CART_ITEMS = 'UPDATE_CART_ITEMS';
 export const CLEAR_CART = 'CLEAR_CART';
 export const CHECKOUT_SUCCESS = 'CHECKOUT_SUCCESS';
 export const CHECKOUT_FAILURE = 'CHECKOUT_FAILURE';
+export const CLEAR_INVALID_CART_ITEMS = 'CLEAR_INVALID_CART_ITEMS';
 
 export const UPDATE_SELECTED_CHAPTERS = 'UPDATE_SELECTED_CHAPTERS';
 export const UPDATE_SEAT_COUNT = 'UPDATE_SEAT_COUNT';
@@ -64,7 +65,7 @@ function requestProductList() {
   };
 }
 
-function receiveProductListSuccess(json) {
+export function receiveProductListSuccess(json) {
   return {
     type: RECEIVE_PRODUCT_LIST_SUCCESS,
     productList: json
@@ -119,6 +120,12 @@ export function fetchProductList() {
     return api.getProductList().
       then(json => dispatch(receiveProductListSuccess(json))).
       catch(() => dispatch(receiveProductListFailure()));
+  };
+}
+
+export function clearInvalidCartItems() {
+  return {
+    type: CLEAR_INVALID_CART_ITEMS
   };
 }
 

--- a/static/js/components/BuyTab.js
+++ b/static/js/components/BuyTab.js
@@ -38,12 +38,18 @@ class BuyTab extends React.Component {
     let cartContents = <MenuItem>No course chapters selected</MenuItem>;
 
     if (cart.cart.length > 0) {
-      cartContents = cart.cart.map((module, i) =>
-        <MenuItem
-          key={module.upc}>{i}: {getProduct(module.upc, productList).title}:
+      cartContents = cart.cart.map((module, i) => {
+        let cartProduct = getProduct(module.upc, productList);
+        let title = "";
+        if (cartProduct !== undefined) {
+          title = cartProduct.title;
+        }
+
+        return <MenuItem
+          key={module.upc}>{i}: {title}:
           Seats: {module.seats}
-        </MenuItem>
-      );
+        </MenuItem>;
+      });
     }
 
     const maxSeats = 200;

--- a/static/js/containers/CourseDetailPage.js
+++ b/static/js/containers/CourseDetailPage.js
@@ -3,6 +3,7 @@ import CourseDetail from '../components/CourseDetail';
 import {
   fetchProduct,
   fetchProductList,
+  clearInvalidCartItems,
   FETCH_FAILURE,
   FETCH_SUCCESS,
 } from '../actions/index_page';
@@ -31,11 +32,14 @@ class CourseDetailPage extends React.Component {
       // yet, fetch them now. This might execute the fetch action twice if
       // this component is refreshed before action has a chance to dispatch,
       // but that shouldn't cause any problems
+
       if (product.productStatus === undefined) {
         dispatch(fetchProduct("Course_" + uuid));
       }
       if (product.productListStatus === undefined) {
-        dispatch(fetchProductList());
+        dispatch(fetchProductList()).then(() => {
+          return dispatch(clearInvalidCartItems());
+        });
       }
     }
   }

--- a/static/js/reducers/index_page.js
+++ b/static/js/reducers/index_page.js
@@ -23,11 +23,13 @@ import {
   ACTIVATE_FAILURE,
   ACTIVATE,
   CLEAR_CART,
+  CLEAR_INVALID_CART_ITEMS,
   UPDATE_CART_ITEMS,
   UPDATE_SELECTED_CHAPTERS,
   UPDATE_SEAT_COUNT,
   UPDATE_CART_VISIBILITY,
 } from '../actions/index_page';
+import { filterCart } from '../util/util';
 
 const INITIAL_PRODUCT_STATE = {
   productList: []
@@ -168,6 +170,11 @@ const INITIAL_CART_STATE = {
 };
 export function cart(state = INITIAL_CART_STATE, action) {
   switch (action.type) {
+  case RECEIVE_PRODUCT_LIST_SUCCESS:
+    // we need this to know what products are missing or not
+    return Object.assign({}, state, {
+      productList: action.productList
+    });
   case UPDATE_CART_ITEMS:
     const { upcs, seats, courseUpc } = action;
     // Remove all items for this particular course
@@ -185,6 +192,10 @@ export function cart(state = INITIAL_CART_STATE, action) {
   case CLEAR_CART:
     return Object.assign({}, state, {
       cart: []
+    });
+  case CLEAR_INVALID_CART_ITEMS:
+    return Object.assign({}, state, {
+      cart: filterCart(state.cart, state.productList)
     });
   default:
     return state;

--- a/static/js/util/util.js
+++ b/static/js/util/util.js
@@ -16,10 +16,9 @@ export function calculateTotal(cart, products) {
 
   for (let item of cart) {
     let product = productLookup[item.upc];
-    if (product === undefined) {
-      throw "Missing product " + item.upc;
+    if (product !== undefined) {
+      total += item.seats * product.price_without_tax;
     }
-    total += item.seats * product.price_without_tax;
   }
 
   return total;
@@ -27,9 +26,11 @@ export function calculateTotal(cart, products) {
 
 export function getProduct(upc, products) {
   let productLookup = makeProductLookup(products);
-  let product = productLookup[upc];
-  if (product === undefined) {
-    throw "Missing product " + upc;
-  }
-  return product;
+  return productLookup[upc];
+}
+
+export function filterCart(cart, products) {
+  let productLookup = makeProductLookup(products);
+
+  return cart.filter(item => productLookup[item.upc] !== undefined);
 }

--- a/static/js/util/util_test.js
+++ b/static/js/util/util_test.js
@@ -1,7 +1,7 @@
 /* global SETTINGS:false */
 import '../global_init';
 import assert from 'assert';
-import { calculateTotal, getProduct } from './util';
+import { calculateTotal, filterCart, getProduct } from './util';
 import { CART_WITH_ITEM, PRODUCT_RESPONSE } from './../constants';
 
 describe('utility functions', () => {
@@ -13,15 +13,16 @@ describe('utility functions', () => {
     assert.equal(calculateTotal(CART_WITH_ITEM, [PRODUCT_RESPONSE]), 99);
   });
 
-  it('fails to calculate the total if a product is missing from the product list', () => {
+  it('skips items which are missing from the product list when calculating the total', () => {
     const cart = [{
       upc: "some other upc",
       seats: 3
     }];
 
-    assert.throws(() => {
-      calculateTotal(cart, [PRODUCT_RESPONSE]);
-    }, /Missing product/);
+    assert.deepEqual(
+      calculateTotal(cart, [PRODUCT_RESPONSE]),
+      0
+    );
   });
 
   it('looks up a product', () => {
@@ -36,8 +37,21 @@ describe('utility functions', () => {
   });
 
   it('fails to look up a product if it is missing', () => {
-    assert.throws(() => {
-      getProduct("missing", [PRODUCT_RESPONSE]);
-    }, /Missing product/);
+    assert.deepEqual(
+      getProduct("missing", [PRODUCT_RESPONSE]),
+      undefined
+    );
+  });
+
+  it('filters out missing items from a cart', () => {
+    assert.deepEqual(
+      filterCart(CART_WITH_ITEM, [PRODUCT_RESPONSE]),
+      CART_WITH_ITEM
+    );
+    // No products, so all items filtered out
+    assert.deepEqual(
+      filterCart(CART_WITH_ITEM, []),
+      []
+    );
   });
 });


### PR DESCRIPTION
Fixes #180 

This changes the behavior of the utility functions to ignore cart items that don't match up to products, and to filter out those cart items that don't match any product.
