### PR TITLE
Added a visible total, updated both when the user moves the slider and selects chapters.

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "isomorphic-fetch": "~2.2.0",
     "jsx-loader": "^0.13.2",
     "lodash": "^3.10.1",
-    "material-ui": "^0.13.2",
+    "material-ui": "^0.14.2",
     "node-neat": "^1.7.2",
     "node-sass": "^3.4.2",
     "react": "^0.14.2",

--- a/static/js/components/BuyTab.js
+++ b/static/js/components/BuyTab.js
@@ -9,7 +9,6 @@ import NavigationClose from 'material-ui/lib/svg-icons/navigation/close';
 import ChapterTab from './ChapterTab';
 import StripeButton from './StripeButton';
 import { getProduct } from '../util/util';
-import { calculateTotal } from '../util/util';
 
 class BuyTab extends React.Component {
   componentWillReceiveProps(nextProps) {
@@ -32,10 +31,11 @@ class BuyTab extends React.Component {
       productList,
       cart,
       buyTab,
+      total,
       updateSelectedChapters,
       } = this.props;
 
-    let cartContents = <MenuItem>No course chapters selected</MenuItem>;
+    let cartContents = <MenuItem>No chapters selected</MenuItem>;
 
     if (cart.cart.length > 0) {
       cartContents = cart.cart.map((module, i) => {
@@ -54,7 +54,6 @@ class BuyTab extends React.Component {
 
     const maxSeats = 200;
 
-    // TODO: Move slider to subcomponent, taking size as params.
     return <div className="course-purchase-selector">
       <div className="seat-number-selector">
         <h3 className="slider-label">Seats</h3>
@@ -77,7 +76,7 @@ class BuyTab extends React.Component {
           </div>
         </div>
         <div className="seatCount">{buyTab.seats}<br /><span className="seatCountLabel">Seats</span></div>
-        <div className="selectionTotal">$2,755<br /><span className="selectionTotalLabel">Total</span></div>
+        <div className="selectionTotal">${total}<br /><span className="selectionTotalLabel">Total</span></div>
         <RaisedButton
           label="Update Cart"
           className="add-to-cart"
@@ -102,9 +101,10 @@ class BuyTab extends React.Component {
       <LeftNav
         docked={false}
         openRight={true}
-        onNavClose={this.onCartClose.bind(this)}
+        onRequestChange={this.onCartClose.bind(this)}
         ref="shoppingCart"
         className="shopping-cart"
+        width={400}
       >
         <AppBar
           title="Cart Summary"
@@ -115,8 +115,12 @@ class BuyTab extends React.Component {
           }
         />
         {cartContents}
-        <span className="cart-total">{cart.total}</span>
-        <StripeButton cart={cart} product={product} checkout={this.onCheckout.bind(this)}/>
+        <div className="cart-actions">
+          <StripeButton cart={cart} product={product} checkout={this.onCheckout.bind(this)}/>
+        </div>
+        <div className="cart-status">
+          <span className="cart-total">${total}<br /><span className="cart-total-label">total cost</span></span>
+        </div>
       </LeftNav>
     </div>;
   }

--- a/static/js/components/ReviewsTab.js
+++ b/static/js/components/ReviewsTab.js
@@ -2,7 +2,6 @@ import React from 'react';
 import List from 'material-ui/lib/lists/list';
 import ListDivider from 'material-ui/lib/lists/list-divider';
 import ListItem from 'material-ui/lib/lists/list-item';
-import Colors from 'material-ui/src/styles/colors';
 import Lorem from './Lorem';
 
 class ReviewsTab extends React.Component {
@@ -12,7 +11,7 @@ class ReviewsTab extends React.Component {
         primaryText="Really Superb Material!"
         secondaryText={
           <p>
-            <span style={{color: Colors.darkBlack}}>Amanda Johnson</span><br/>
+            <span>Amanda Johnson</span><br/>
             <Lorem />
           </p>
         }
@@ -22,7 +21,7 @@ class ReviewsTab extends React.Component {
         primaryText="It's a pleasure to teach with this!"
         secondaryText={
           <p>
-            <span style={{color: Colors.darkBlack}}>Dave Reynolds</span><br/>
+            <span>Dave Reynolds</span><br/>
             <Lorem />
           </p>
         }
@@ -32,7 +31,7 @@ class ReviewsTab extends React.Component {
         primaryText="Terrific Stuff!"
         secondaryText={
           <p>
-            <span style={{color: Colors.darkBlack}}>Marlo Thomas</span><br/>
+            <span>Marlo Thomas</span><br/>
             <Lorem />
           </p>
         }

--- a/static/js/components/StripeButton.js
+++ b/static/js/components/StripeButton.js
@@ -9,10 +9,9 @@ class StripeButton extends React.Component {
 
     return <RaisedButton
       label="Checkout"
-      id="checkout"
+      className="checkout-button"
       onClick={checkout}
       secondary={true}
-      style={{ 'textAlign': 'center', 'display': 'block' }}
     />;
   }
 }

--- a/static/js/containers/BuyTabContainer.js
+++ b/static/js/containers/BuyTabContainer.js
@@ -16,12 +16,15 @@ class BuyTabContainer extends React.Component {
   render() {
     const { product, productList, cart, buyTab } = this.props;
 
+    let total = this.updateTotal();
+
     return <BuyTab
       selectable={true}
       product={product}
       productList={productList}
       cart={cart}
       buyTab={buyTab}
+      total={total}
 
       updateCartItems={this.onUpdateCartItems.bind(this)}
       updateSelectedChapters={this.onUpdateSelectedChapters.bind(this)}
@@ -33,16 +36,40 @@ class BuyTabContainer extends React.Component {
       />;
   }
 
-  onUpdateCartItems(upcs, seats) {
-    const { dispatch, product } = this.props;
+  updateTotal() {
+    const { buyTab, product, productList } = this.props;
 
-    dispatch(updateCartItems(upcs, seats, product.upc));
+    let cart = buyTab.selectedChapters.map(upc => ({
+      upc: upc,
+      seats: buyTab.seats,
+      courseUpc: product.upc
+    }));
+
+    let total = calculateTotal(cart, productList);
+
+    return total;
   }
 
   onUpdateSeatCount(seats) {
     const { dispatch } = this.props;
 
     dispatch(updateSeatCount(seats));
+  }
+
+  onUpdateSelectedChapters(upcs, allRowsSelected) {
+    const { dispatch } = this.props;
+
+    dispatch(updateSelectedChapters(upcs, allRowsSelected));
+  }
+
+  onUpdateCartItems(upcs, seats) {
+    const { dispatch, product } = this.props;
+    dispatch(updateCartItems(upcs, seats, product.upc));
+  }
+
+  onUpdateCartVisibility(visibility) {
+    const { dispatch } = this.props;
+    dispatch(updateCartVisibility(visibility));
   }
 
   onCheckout() {
@@ -58,17 +85,6 @@ class BuyTabContainer extends React.Component {
         amount: Math.floor(total * 100)
       });
     }
-  }
-
-  onUpdateSelectedChapters(upcs, allRowsSelected) {
-    const { dispatch } = this.props;
-
-    dispatch(updateSelectedChapters(upcs, allRowsSelected));
-  }
-
-  onUpdateCartVisibility(visibility) {
-    const { dispatch } = this.props;
-    dispatch(updateCartVisibility(visibility));
   }
 }
 

--- a/static/js/util/util.js
+++ b/static/js/util/util.js
@@ -12,7 +12,9 @@ function makeProductLookup(products) {
 }
 
 export function calculateTotal(cart, products) {
-  let total = 0, productLookup = makeProductLookup(products);
+  let total = 0;
+
+  let productLookup = makeProductLookup(products);
 
   for (let item of cart) {
     let product = productLookup[item.upc];

--- a/static/sass/layout.scss
+++ b/static/sass/layout.scss
@@ -88,14 +88,28 @@ body {
 
 
         .shopping-cart {
-          .cart-total {
-            color: 'green';
-            font-size: 2em;
-            text-align: center;
-            .cart-total-label {
-              font-size: 0.5em;
+
+          .cart-actions {
+            @include pad($block-padding);
+            @include span-columns(6);
+            .checkout-button {
+            }
+          }
+
+          .cart-status {
+            @include pad($block-padding);
+            @include span-columns(6);
+            .cart-total {
+              color: green;
+              font-size: 2em;
+              font-weight: 700;
               text-align: center;
-              font-variant: small-caps;
+              .cart-total-label {
+                color: black;
+                font-size: 0.9em;
+                text-align: center;
+                font-variant: small-caps;
+              }
             }
           }
         }


### PR DESCRIPTION
This PR displays a total cost for the combination of selected number of seats and selected chapters on the "buy tab" of the course detail page, before adding those selections to the cart and when viewing the cart, before checking out to complete the purchase.

**To test**:
- [Assumption] You have a course (an oscar product) and some modules (some variants of that product) in your local db. If not, follow instructions in: https://github.com/mitodl/teachersportal/pull/127
- Visit http://192.168.99.100:8075/courses/0ff00bdc-36d3-43ea-9359-6417182c44c2 (or whatever the uuid of the course you created was)
- Click the "Buy" tab on the course detail page.
- You should see a slider to be used to select the number of seats to be purchased. Slide it to select a number of seats. At this point (until you select chapters), that total will be $0.
- You should see a listing of course modules which can be purchased. Check the modules you wish to purchase. At this point, you will see the total cost of your selection appear in green, and update synchronously as you change your selection.
- Click "Update Cart". You should see a cart sidebar slide out with your selections listed, and a checkout button. You should also see the same total in the cart.
- Click Checkout; after filling in address, and clicking "Payment info", you should see the same total there as well.

Fixes #207 
