### PR TITLE
Added total field to checkout API

### DIFF
--- a/static/js/actions/index_page.js
+++ b/static/js/actions/index_page.js
@@ -167,9 +167,9 @@ export const checkoutSuccess = createAction(CHECKOUT_SUCCESS);
 export const checkoutFailure = createAction(CHECKOUT_FAILURE);
 export const resetBuyTab = createAction(RESET_BUYTAB);
 
-export function checkout(cart, token) {
+export function checkout(cart, token, total) {
   return dispatch => {
-    return api.checkout(cart, token).
+    return api.checkout(cart, token, total).
       then(() => {
         dispatch(checkoutSuccess());
         dispatch(clearCart());

--- a/static/js/containers/BuyTabContainer.js
+++ b/static/js/containers/BuyTabContainer.js
@@ -77,7 +77,7 @@ class BuyTabContainer extends React.Component {
 
     let total = calculateTotal(cart.cart, productList);
     if (total === 0) {
-      dispatch(checkout(cart.cart, ""));
+      dispatch(checkout(cart.cart, "", total));
     } else {
       StripeHandler.open({
         name: 'MIT Teacher\'s Portal',

--- a/static/js/index_page.js
+++ b/static/js/index_page.js
@@ -13,6 +13,7 @@ import { devTools, persistState } from 'redux-devtools';
 import { DevTools, DebugPanel, LogMonitor } from 'redux-devtools/lib/react';
 import { checkout } from './actions/index_page';
 import ga from 'react-ga';
+import { calculateTotal } from './util/util';
 
 const store = configureStore();
 
@@ -27,7 +28,11 @@ StripeHandler = StripeCheckout.configure({
   email: SETTINGS.email,
   token: token => {
     // User has confirmed the intent to pay, now process the transaction
-    store.dispatch(checkout(store.getState().cart.cart, token.id));
+    let total = calculateTotal(
+      store.getState().cart.cart,
+      store.getState().product.productList
+    );
+    store.dispatch(checkout(store.getState().cart.cart, token.id, total));
   }
 });
 

--- a/static/js/reducers/index_test.js
+++ b/static/js/reducers/index_test.js
@@ -360,7 +360,7 @@ describe('reducers', () => {
           productList: []
         });
 
-        dispatchThen(checkout(expectedCart, "token"), 2).then(cartState => {
+        dispatchThen(checkout(expectedCart, "token", 500), 2).then(cartState => {
           assert.deepEqual(cartState, {
             cart: [],
             productList: []
@@ -385,7 +385,7 @@ describe('reducers', () => {
           productList: []
         });
 
-        dispatchThen(checkout(expectedCart, "token")).then(cartState => {
+        dispatchThen(checkout(expectedCart, "token", 500)).then(cartState => {
           assert.deepEqual(cartState, {
             cart: expectedCart,
             productList: []

--- a/static/js/util/api.js
+++ b/static/js/util/api.js
@@ -122,12 +122,13 @@ export function activate(token) {
   });
 }
 
-export function checkout(cart, token) {
+export function checkout(cart, token, total) {
   return fetchJSONWithCSRF('/api/v1/checkout/', {
     method: 'POST',
     body: JSON.stringify({
       cart: cart,
-      token: token
+      token: token,
+      total: total
     })
   });
 }

--- a/static/js/util/api_test.js
+++ b/static/js/util/api_test.js
@@ -173,7 +173,8 @@ describe('common api functions', function() {
         upc: "upc",
         seats: 5
       }],
-      token: "token"
+      token: "token",
+      total: 500
     };
 
     fetchMock.mock('/api/v1/checkout/', (url, opts) => {
@@ -182,7 +183,7 @@ describe('common api functions', function() {
         status: 200
       };
     });
-    checkout(expected.cart, expected.token).then(() => {
+    checkout(expected.cart, expected.token, expected.total).then(() => {
       done();
     });
   });
@@ -191,7 +192,8 @@ describe('common api functions', function() {
     let expected = {
       cart: [{
         upc: "upc",
-        seats: 5
+        seats: 5,
+        total: 500
       }],
       token: "token"
     };
@@ -202,7 +204,7 @@ describe('common api functions', function() {
         status: 400
       };
     });
-    checkout(expected.cart, expected.token).catch(() => {
+    checkout(expected.cart, expected.token, expected.total).catch(() => {
       done();
     });
   });


### PR DESCRIPTION
#### What's this PR do?

Adds a required `total` field to the checkout API which will help verify that the amount shown to the user in Stripe matches the total shown in the Python code.
#### Where should the reviewer start?

`portal/views/checkout_api.py`
#### How should this be manually tested?

You can try adjusting the javascript `calculateTotal` method and making sure that the checkout fails when the totals don't match up.
#### What are the relevant tickets?

Fixes #209
