### PR TITLE
Split webpack config into dev and production files

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,7 +36,7 @@ watch:
     npm install --no-bin-links &&
     npm rebuild node-sass &&
     echo Finished npm install &&
-    node ./node_modules/webpack-dev-server/bin/webpack-dev-server.js -d --content-base ./static --host 0.0.0.0 --port 8076 --progress --inline'
+    node ./node_modules/webpack-dev-server/bin/webpack-dev-server.js --config webpack.config.dev.js -d --content-base ./static --host 0.0.0.0 --port 8076 --progress --inline'
   ports:
     - "8076:8076"
   volumes:

--- a/package.json
+++ b/package.json
@@ -54,6 +54,6 @@
     "webpack-stats-plugin": "^0.1.1"
   },
   "scripts": {
-    "postinstall": "node node_modules/webpack/bin/webpack.js"
+    "postinstall": "node node_modules/webpack/bin/webpack.js --config webpack.config.prod.js"
   }
 }

--- a/static/js/root.js
+++ b/static/js/root.js
@@ -41,6 +41,13 @@ window.onpopstate = () => {
   StripeHandler.close();
 };
 
+let debugTools;
+if (process.env.NODE_ENV !== 'production') {
+  debugTools = <DebugPanel top right bottom>
+    <DevTools store={store} monitor={LogMonitor} visibleOnLoad={false}/>
+  </DebugPanel>;
+}
+
 ReactDOM.render(
   <div>
     <Provider store={store}>
@@ -51,9 +58,7 @@ ReactDOM.render(
         </Route>
       </Router>
     </Provider>
-    <DebugPanel top right bottom>
-      <DevTools store={store} monitor={LogMonitor} visibleOnLoad={false}/>
-    </DebugPanel>
+    {debugTools}
   </div>,
   document.getElementById("container")
 );

--- a/static/js/store/configureStore.js
+++ b/static/js/store/configureStore.js
@@ -6,15 +6,25 @@ import rootReducer from '../reducers';
 import { persistState as devToolsPersistState, devTools } from 'redux-devtools';
 import localStoragePersistState from 'redux-localstorage';
 
-const createStoreWithMiddleware = compose(
-  applyMiddleware(
-    thunkMiddleware,
-    createLogger()
-  ),
-  localStoragePersistState("cart"),
-  devTools(),
-  devToolsPersistState(window.location.href.match(/[?&]debug_session=([^&]+)\b/))
-)(createStore);
+let createStoreWithMiddleware;
+if (process.env.NODE_ENV !== "production") {
+  createStoreWithMiddleware = compose(
+    applyMiddleware(
+      thunkMiddleware,
+      createLogger()
+    ),
+    localStoragePersistState("cart"),
+    devTools(),
+    devToolsPersistState(window.location.href.match(/[?&]debug_session=([^&]+)\b/))
+  )(createStore);
+} else {
+  createStoreWithMiddleware = compose(
+    applyMiddleware(
+      thunkMiddleware
+    ),
+    localStoragePersistState("cart")
+  )(createStore);
+}
 
 export default function configureStore(initialState) {
   const store = createStoreWithMiddleware(rootReducer, initialState);

--- a/webpack.config.dev.js
+++ b/webpack.config.dev.js
@@ -1,13 +1,11 @@
-var Promise = require('es6-promise').Promise;
 var path = require("path");
 var webpack = require('webpack');
-var BundleTracker = require('webpack-bundle-tracker');
 var NodeNeat = require("node-neat");
 
 module.exports = {
   context: __dirname,
   entry: {
-    'index_page': './static/js/index_page'
+    'index_page': './static/js/root'
   },
   output: {
     path: path.resolve('./static/bundles/'),
@@ -41,9 +39,9 @@ module.exports = {
     extensions: ['', '.js', '.jsx']
   },
   plugins: [
-    new webpack.optimize.UglifyJsPlugin({
-      compress: {
-        warnings: false
+    new webpack.DefinePlugin({
+      'process.env': {
+        'NODE_ENV': '"development"'
       }
     })
   ],

--- a/webpack.config.prod.js
+++ b/webpack.config.prod.js
@@ -1,0 +1,54 @@
+var path = require("path");
+var webpack = require('webpack');
+var NodeNeat = require("node-neat");
+
+module.exports = {
+  context: __dirname,
+  entry: {
+    'index_page': './static/js/root'
+  },
+  output: {
+    path: path.resolve('./static/bundles/'),
+    filename: "[name].js"
+  },
+
+  module: {
+    loaders: [
+      {
+        test: /\.jsx?$/,
+        exclude: /node_modules/,
+        loader: 'babel-loader',
+        query: {
+          presets: ['es2015', 'react']
+        }
+      },  // to transform JSX into JS
+      {
+        test: /\.scss$/,
+        exclude: /node_modules/,
+        loader: 'style!css!sass'
+      }
+    ]
+  },
+
+  sassLoader: {
+    includePaths: NodeNeat.includePaths
+  },
+
+  resolve: {
+    modulesDirectories: ['node_modules'],
+    extensions: ['', '.js', '.jsx']
+  },
+  plugins: [
+    new webpack.DefinePlugin({
+      'process.env': {
+        'NODE_ENV': '"production"'
+      }
+    }),
+    new webpack.optimize.UglifyJsPlugin({
+      compress: {
+        warnings: false
+      }
+    })
+  ],
+  devtool: 'source-map'
+};


### PR DESCRIPTION
Fixes #109

To manually test this, make sure you can see the website when you do `docker-compose up`. Make sure you can see logging in the console when you click on the 'Sign in' button. Then change `docker-compose.yml` to point `webpack-dev-server` to `webpack.config.prod.js`. The website should still work when you run `docker-compose up` and you should **not** see logging statements in the console anymore.
