### PR TITLE
Implemented Course Listing

### DIFF
--- a/static/js/components/CourseCard.js
+++ b/static/js/components/CourseCard.js
@@ -1,0 +1,48 @@
+import React, { Component, PropTypes } from 'react';
+import { bindActionCreators } from 'redux';
+import { connect } from 'react-redux';
+import { Link } from 'react-router';
+import Card from 'material-ui/lib/card/card';
+import CourseCardImage from './CourseCardImage';
+import CardTitle from 'material-ui/lib/card/card-title';
+import CardText from 'material-ui/lib/card/card-text';
+import CircularProgress from 'material-ui/lib/circular-progress';
+
+class CourseCard extends Component {
+  render() {
+    const {
+      course,
+    } = this.props;
+
+    let path = "/courses/" + course.uuid;
+
+    let ccxDescription = course.info ? course.info.description : "";
+    let description = course.description || ccxDescription;
+
+    let content = <Card className="course-card">
+      <CourseCardImage src="http://lorempixel.com/305/75/abstract/" />
+      <Link to={path}>
+        <CardTitle
+          title={course.title}
+          className="course-card-title"
+        />
+      </Link>
+      <CardText
+        className="course-card-description"
+        dangerouslySetInnerHTML={{__html: description }}
+      />
+    </Card>;
+
+    return <div className="course-card-body">
+      <Card className="course-card-content">
+        {content}
+      </Card>
+    </div>;
+  }
+}
+
+CourseCard.propTypes = {
+  course: React.PropTypes.object.isRequired,
+};
+
+export default CourseCard;

--- a/static/js/components/CourseCardImage.js
+++ b/static/js/components/CourseCardImage.js
@@ -1,0 +1,22 @@
+import React, { Component, PropTypes } from 'react';
+import Card from 'material-ui/lib/card/card';
+import CardMedia from 'material-ui/lib/card/card-media';
+
+class CourseCardImage extends Component {
+  render() {
+    const { src } = this.props;
+    let image = src;
+
+    return <Card className="course-card-image">
+      <CardMedia style={{'width': "300px"}}>
+        <img src={image} alt="Course detail image"/>
+      </CardMedia>
+    </Card>;
+  }
+}
+
+export default CourseCardImage;
+
+CourseCardImage.propTypes = {
+  src: React.PropTypes.string.isRequired
+};

--- a/static/js/containers/App.js
+++ b/static/js/containers/App.js
@@ -2,8 +2,8 @@ import React from 'react';
 import Header from '../components/Header';
 import Footer from '../components/Footer';
 import SnackbarWrapper from '../components/SnackbarWrapper';
-import { connect } from 'react-redux';
 import RaisedButton from 'material-ui/lib/raised-button';
+import { connect } from 'react-redux';
 
 import {
   showLogin,

--- a/static/js/containers/CourseListing.js
+++ b/static/js/containers/CourseListing.js
@@ -1,0 +1,60 @@
+import React from 'react';
+import Card from 'material-ui/lib/card/card';
+import CourseCard from '../components/CourseCard';
+import {
+  fetchCourseList,
+  clearInvalidCartItems,
+  FETCH_FAILURE,
+  FETCH_SUCCESS,
+} from '../actions/index_page';
+import { connect } from 'react-redux';
+
+class CourseListing extends React.Component {
+
+  componentDidMount() {
+    this.fetchCourseList();
+  }
+
+  componentDidUpdate() {
+    this.fetchCourseList();
+  }
+
+  fetchCourseList() {
+    const { course, dispatch } = this.props;
+    if (course.courseListStatus === undefined) {
+      dispatch(fetchCourseList()).then(() => {
+        return dispatch(clearInvalidCartItems());
+      });
+    }
+  }
+
+  render() {
+    const { course } = this.props;
+
+    let list = course.courseList.map((course) => {
+      return <li className="course-card-item" key={course.uuid}>
+        <CourseCard course={course} />
+      </li>;
+    });
+
+    return <Card id="course-body" style={{ 'backgroundColor': "#eee" }}>
+      <h2 className="course-listing-header">Use MIT's courses in your teachings</h2>
+      <ul className="course-listing">
+        {list}
+      </ul>
+      </Card>;
+  }
+}
+
+CourseListing.propTypes = {
+  dispatch: React.PropTypes.func.isRequired,
+  course: React.PropTypes.object.isRequired,
+};
+
+const mapStateToProps = (state) => {
+  return {
+    course: state.course,
+  };
+};
+
+export default connect(mapStateToProps)(CourseListing);

--- a/static/js/root.js
+++ b/static/js/root.js
@@ -3,11 +3,12 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import '../sass/layout.scss';
 import App from './containers/App';
+import CourseListing from './containers/CourseListing';
 import CourseDetailPage from './containers/CourseDetailPage';
 import ActivatePage from './containers/ActivatePage';
 import { Provider } from 'react-redux';
 import configureStore from './store/configureStore';
-import { Router, Route } from 'react-router';
+import { Router, Route, IndexRoute } from 'react-router';
 import createBrowserHistory from 'history/lib/createBrowserHistory';
 import { devTools, persistState } from 'redux-devtools';
 import { DevTools, DebugPanel, LogMonitor } from 'redux-devtools/lib/react';
@@ -53,6 +54,7 @@ ReactDOM.render(
     <Provider store={store}>
       <Router history={createBrowserHistory()}>
         <Route path="/" component={App} onUpdate={ga.pageview(window.location.pathname)}>
+          <IndexRoute component={CourseListing} />
           <Route path="courses/:uuid" component={CourseDetailPage} />
           <Route path="activate" component={ActivatePage} />
         </Route>

--- a/static/sass/layout.scss
+++ b/static/sass/layout.scss
@@ -41,6 +41,37 @@ body {
       background-color: $lightgrey;
       border: 1px solid #ddd;
 
+      h2.course-listing-header {
+        padding: 0 40px;
+        font-weight: 700;
+        font-size: 1.5em;
+        color: #B30000;
+      }
+
+      ul.course-listing {
+        @include outer-container;
+        li.course-card-item {
+          @include span-columns(3);
+          @include omega(4n);
+          margin-bottom: 20px;
+          .course-card-body {
+            .course-card-content {
+              .course-card {
+                a {
+                  text-decoration: none;
+                  .course-card-title {
+                    font-size: 18px;
+                    line-height: 30px;
+                    font-weight: 700;
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+
+
       #course-content {
         @include pad($page-padding);
         #course-title {


### PR DESCRIPTION
Adds:
- A course card (a thumbnail view for a listing page)
- A course listing, consisting of n rows of four course cards across.

To do:
- [x] Allow authenticated users (only) to view the course detail page
- ~~Allow unauthenticated users to see the listing.~~  [will do in another PR]
- ~~Prompt for login when user clicks a course card if they're not logged in.~~  [will do in another PR]
- ~~After login, rerender homepage.~~  [will do in another PR]

Notes
- Currently rebased on #264 

Fixes: #245 and #246
