### PR TITLE
Added support for capturing ecommerce conversions in Google Analytics

### DIFF
--- a/static/js/actions/index_page.js
+++ b/static/js/actions/index_page.js
@@ -1,5 +1,6 @@
 import * as api from '../util/api';
 import { createAction } from 'redux-actions';
+import { sendGoogleAnalyticsEvent, sendGoogleEcommerceTransaction } from '../util/util';
 
 // action type constants
 export const REQUEST_COURSE = 'REQUEST_COURSE';
@@ -157,8 +158,10 @@ export function activate(token) {
     return api.activate(token).
       then(() => {
         dispatch(activateSuccess());
+        sendGoogleAnalyticsEvent("User", "Activation", "Success");
       }).catch(e => {
         dispatch(activateFailure());
+        sendGoogleAnalyticsEvent("User", "Activation", "Failure");
         // let anything afterwards catch the error too
         return Promise.reject(e);
       });
@@ -180,9 +183,11 @@ export function checkout(cart, token, total) {
         dispatch(checkoutSuccess());
         dispatch(clearCart());
         dispatch(resetBuyTab());
+        sendGoogleEcommerceTransaction(token, total);
       }).
       catch(e => {
         dispatch(checkoutFailure());
+        sendGoogleAnalyticsEvent("Purchase", "Rejected", "Failure", total);
         return Promise.reject(e);
       });
   };

--- a/static/js/util/util.js
+++ b/static/js/util/util.js
@@ -1,3 +1,5 @@
+import ga from 'react-ga';
+
 function makeModuleLookup(courses) {
   let moduleLookup = {};
 
@@ -34,4 +36,25 @@ export function filterCart(cart, courses) {
   let moduleLookup = makeModuleLookup(courses);
 
   return cart.filter(item => moduleLookup[item.uuid] !== undefined);
+}
+
+export function sendGoogleAnalyticsEvent(category, action, label, value) {
+  let event = {
+    category: category,
+    action: action,
+    label: label,
+  };
+  if (value !== undefined) {
+    event.value = value;
+  }
+  ga.event(event);
+}
+
+export function sendGoogleEcommerceTransaction(id, revenue) {
+  ga.plugin.require('ecommerce');
+  ga.plugin.execute('ecommerce', 'addTransaction', {
+    'Transaction ID': id,
+    'revenue': revenue
+  });
+  ga.plugin.execute('ecommerce', 'send');
 }


### PR DESCRIPTION
Currently firing conversion events from within checkout actions. Per a conversation with @justinabrahms I am going to look into doing this via middleware instead. See: https://github.com/markdalgleish/redux-analytics

Fixes #248  
