### PR TITLE
Altered cart to move seats count to the course level

### DIFF
--- a/portal/models.py
+++ b/portal/models.py
@@ -109,7 +109,7 @@ class Order(models.Model):
 
 class OrderLine(models.Model):
     """
-    An item purchased
+    A module which is purchased.
     """
     order = ForeignKey(Order)
     seats = IntegerField()

--- a/static/js/components/BuyTab.js
+++ b/static/js/components/BuyTab.js
@@ -8,7 +8,7 @@ import IconButton from 'material-ui/lib/icon-button';
 import NavigationClose from 'material-ui/lib/svg-icons/navigation/close';
 import ChapterTab from './ChapterTab';
 import StripeButton from './StripeButton';
-import { getModule, calculateTotal } from '../util/util';
+import { getModule, getCourse, calculateTotal } from '../util/util';
 
 class BuyTab extends React.Component {
   componentWillReceiveProps(nextProps) {
@@ -39,14 +39,14 @@ class BuyTab extends React.Component {
 
     if (cart.cart.length > 0) {
       cartContents = cart.cart.map((item, i) => {
-        let module = getModule(item.uuid, courseList);
+        let course = getCourse(item.courseUuid, courseList);
         let title = "";
-        if (module !== undefined) {
-          title = module.title;
+        if (course !== undefined) {
+          title = course.title;
         }
 
         return <MenuItem
-          key={item.uuid}>{i}: {title}:
+          key={item.courseUuid}>{i}: {title}:
           Seats: {item.seats}
         </MenuItem>;
       });

--- a/static/js/constants.js
+++ b/static/js/constants.js
@@ -59,12 +59,12 @@ export const COURSE_LIST = [COURSE_RESPONSE1, COURSE_RESPONSE2];
 
 export const CART = [
   {
-    uuid: COURSE_RESPONSE1.modules[0].uuid,
+    uuids: [COURSE_RESPONSE1.modules[0].uuid],
     seats: 3,
     courseUuid: COURSE_RESPONSE1.uuid
   },
   {
-    uuid: COURSE_RESPONSE2.modules[0].uuid,
+    uuids: [COURSE_RESPONSE2.modules[0].uuid],
     seats: 4,
     courseUuid: COURSE_RESPONSE2.uuid
   }

--- a/static/js/containers/BuyTabContainer.js
+++ b/static/js/containers/BuyTabContainer.js
@@ -39,11 +39,11 @@ class BuyTabContainer extends React.Component {
   updateTotal() {
     const { buyTab, course, courseList } = this.props;
 
-    let cart = buyTab.selectedChapters.map(uuid => ({
-      uuid: uuid,
+    let cart = [{
+      courseUuid: course.uuid,
       seats: buyTab.seats,
-      courseUuid: course.uuid
-    }));
+      uuids: buyTab.selectedChapters
+    }];
 
     let total = calculateTotal(cart, courseList);
 
@@ -81,7 +81,7 @@ class BuyTabContainer extends React.Component {
     } else {
       StripeHandler.open({
         name: 'MIT Teacher\'s Portal',
-        description: cart.cart.length + ' item(s)',
+        description: cart.cart.length + ' course(s)',
         amount: Math.floor(total * 100)
       });
     }

--- a/static/js/reducers/index_page.js
+++ b/static/js/reducers/index_page.js
@@ -147,14 +147,10 @@ export const cart = handleActions({
 
   UPDATE_CART_ITEMS: (state, action) => {
     const { uuids, seats, courseUuid } = action.payload;
-    // Remove all items for this particular course
     let newCart = state.cart.filter(item => item.courseUuid !== courseUuid);
-    let newItems = uuids.map(uuid => ({
-      uuid: uuid,
-      seats: seats,
-      courseUuid: courseUuid
-    }));
-    newCart = newCart.concat(newItems);
+    if (uuids.length > 0) {
+      newCart = newCart.concat({uuids, seats, courseUuid});
+    }
 
     return Object.assign({}, state, {
       cart: newCart

--- a/static/js/reducers/index_test.js
+++ b/static/js/reducers/index_test.js
@@ -370,7 +370,7 @@ describe('reducers', () => {
       dispatchThen(updateCartItems(['uuid'], 3, 'courseUuid')).then(cartState => {
         assert.deepEqual(cartState, {
           cart: [{
-            uuid: 'uuid',
+            uuids: ['uuid'],
             seats: 3,
             courseUuid: 'courseUuid'
           }],
@@ -381,7 +381,7 @@ describe('reducers', () => {
         dispatchThen(updateCartItems(['newUuid'], 5, 'courseUuid')).then(cartState => {
           assert.deepEqual(cartState, {
             cart: [{
-              uuid: 'newUuid',
+              uuids: ['newUuid'],
               seats: 5,
               courseUuid: 'courseUuid'
             }],
@@ -392,11 +392,11 @@ describe('reducers', () => {
           dispatchThen(updateCartItems(['uuid'], 4, 'othercourseUuid')).then(cartState => {
             assert.deepEqual(cartState, {
               cart: [{
-                uuid: 'newUuid',
+                uuids: ['newUuid'],
                 seats: 5,
                 courseUuid: 'courseUuid'
               }, {
-                uuid: 'uuid',
+                uuids: ['uuid'],
                 seats: 4,
                 courseUuid: 'othercourseUuid'
               }],
@@ -413,7 +413,7 @@ describe('reducers', () => {
 
       dispatchThen(updateCartItems(['uuid'], 5, 'courseUuid')).then(cartState => {
         let expectedCart = [{
-          uuid: 'uuid',
+          uuids: ['uuid'],
           seats: 5,
           courseUuid: 'courseUuid'
         }];
@@ -438,7 +438,7 @@ describe('reducers', () => {
 
       dispatchThen(updateCartItems(['uuid'], 5, 'courseUuid')).then(cartState => {
         let expectedCart = [{
-          uuid: 'uuid',
+          uuids: ['uuid'],
           seats: 5,
           courseUuid: 'courseUuid'
         }];
@@ -463,7 +463,7 @@ describe('reducers', () => {
       let courseUuid = COURSE_RESPONSE1.uuid;
       dispatchThen(updateCartItems([uuid], 5, courseUuid)).then(cartState => {
         let expectedCart = [{
-          uuid: uuid,
+          uuids: [uuid],
           seats: 5,
           courseUuid: courseUuid
         }];

--- a/static/js/util/api.js
+++ b/static/js/util/api.js
@@ -123,10 +123,17 @@ export function activate(token) {
 }
 
 export function checkout(cart, token, total) {
+  // Convert to Python naming conventions
+  let cartWithUnderscores = cart.map(item => ({
+    uuids: item.uuids,
+    seats: item.seats,
+    course_uuid: item.courseUuid  // eslint-disable-line camelcase
+  }));
+
   return fetchJSONWithCSRF('/api/v1/checkout/', {
     method: 'POST',
     body: JSON.stringify({
-      cart: cart,
+      cart: cartWithUnderscores,
       token: token,
       total: total
     })

--- a/static/js/util/api_test.js
+++ b/static/js/util/api_test.js
@@ -168,43 +168,59 @@ describe('common api functions', function() {
   });
 
   it('checks out successfully', done => {
-    let expected = {
+    let input = {
       cart: [{
-        uuid: "uuid",
-        seats: 5
+        uuids: ["uuid"],
+        seats: 5,
+        courseUuid: "courseUuid"
       }],
       token: "token",
       total: 500
     };
+    let output = Object.assign({}, input, {
+      cart: input.cart.map(item => ({
+        uuids: item.uuids,
+        seats: item.seats,
+        course_uuid: item.courseUuid  // eslint-disable-line camelcase
+      }))
+    });
 
     fetchMock.mock('/api/v1/checkout/', (url, opts) => {
-      assert.deepEqual(JSON.parse(opts.body), expected);
+      assert.deepEqual(JSON.parse(opts.body), output);
       return {
         status: 200
       };
     });
-    checkout(expected.cart, expected.token, expected.total).then(() => {
+    checkout(input.cart, input.token, input.total).then(() => {
       done();
     });
   });
 
   it('fails to checkout', done => {
-    let expected = {
+    let input = {
       cart: [{
-        uuid: "uuid",
+        uuids: ["uuid"],
         seats: 5,
-        total: 500
+        courseUuid: "courseUuid"
       }],
-      token: "token"
+      token: "token",
+      total: 500
     };
+    let output = Object.assign({}, input, {
+      cart: input.cart.map(item => ({
+        uuids: item.uuids,
+        seats: item.seats,
+        course_uuid: item.courseUuid  // eslint-disable-line camelcase
+      }))
+    });
 
     fetchMock.mock('/api/v1/checkout/', (url, opts) => {
-      assert.deepEqual(JSON.parse(opts.body), expected);
+      assert.deepEqual(JSON.parse(opts.body), output);
       return {
         status: 400
       };
     });
-    checkout(expected.cart, expected.token, expected.total).catch(() => {
+    checkout(input.cart, input.token, input.total).catch(() => {
       done();
     });
   });

--- a/static/js/util/util_test.js
+++ b/static/js/util/util_test.js
@@ -1,7 +1,7 @@
 /* global SETTINGS:false */
 import '../global_init';
 import assert from 'assert';
-import { calculateTotal, filterCart, getModule } from './util';
+import { calculateTotal, filterCart, getModule, getCourse } from './util';
 import { CART, COURSE_RESPONSE1, COURSE_LIST } from './../constants';
 
 describe('utility functions', () => {
@@ -12,8 +12,10 @@ describe('utility functions', () => {
   it('calculates the total of a cart', () => {
     let sum = 0;
     for (let item of CART) {
-      let module = getModule(item.uuid, COURSE_LIST);
-      sum += item.seats * module.price_without_tax;
+      for (let uuid of item.uuids) {
+        let module = getModule(uuid, COURSE_LIST);
+        sum += item.seats * module.price_without_tax;
+      }
     }
     assert.equal(
       calculateTotal(CART, COURSE_LIST),
@@ -22,10 +24,9 @@ describe('utility functions', () => {
   });
 
   it('skips items which are missing from the course list when calculating the total', () => {
-    const cart = [{
-      uuid: "some other uuid",
-      seats: 3
-    }];
+    const cart = [Object.assign({}, CART[0], {
+      uuids: ["some other uuid"]
+    })];
 
     assert.deepEqual(
       calculateTotal(cart, COURSE_LIST),
@@ -52,6 +53,25 @@ describe('utility functions', () => {
     );
   });
 
+  it('looks up a course', () => {
+    assert.deepEqual(
+      getCourse(COURSE_RESPONSE1.uuid, COURSE_LIST),
+      COURSE_RESPONSE1
+    );
+    // No modules in course lookup
+    assert.deepEqual(
+      getCourse(COURSE_RESPONSE1.modules[0].uuid, COURSE_LIST),
+      undefined
+    );
+  });
+
+  it('fails to get a course if it is missing', () => {
+    assert.deepEqual(
+      getCourse("missing", COURSE_LIST),
+      undefined
+    );
+  });
+
   it('filters out missing items from a cart', () => {
     assert.deepEqual(
       filterCart(CART, COURSE_LIST),
@@ -62,5 +82,44 @@ describe('utility functions', () => {
       filterCart(CART, []),
       []
     );
+  });
+
+  describe('invalid items in a cart', () => {
+    it('filters invalid types from a cart', () => {
+      // Unless there is at least one valid item, return an empty list
+      for (let input of [[], {}, null, "", 3]) {
+        assert.deepEqual(filterCart(input, COURSE_LIST), []);
+      }
+    });
+
+    it('filters items with missing or invalid keys', () => {
+      for (let key of ["uuids", "courseUuid", "seats"]) {
+        let item = Object.assign({}, CART[0]);
+        delete item[key];
+        assert.deepEqual(filterCart([item], COURSE_LIST), []);
+      }
+    });
+
+    it('filters items with invalid keys', () => {
+      for (let key of ["uuids", "courseUuid", "seats"]) {
+        let item = Object.assign({}, CART[0]);
+        item[key] = 'invalid';
+        assert.deepEqual(filterCart([item], COURSE_LIST), []);
+      }
+    });
+
+    it('filters out only modules that don\'t match up', () => {
+      let item = Object.assign({}, CART[0], {
+        uuids: ["invalid"].concat(CART[0].uuids)
+      });
+      assert.deepEqual(filterCart([item], COURSE_LIST), [CART[0]]);
+    });
+
+    it('filters out courses where all modules don\'t match up', () => {
+      let item = Object.assign({}, CART[0], {
+        uuids: ["invalid"]
+      });
+      assert.deepEqual(filterCart([item], COURSE_LIST), []);
+    });
   });
 });


### PR DESCRIPTION
#### What are the relevant tickets?

Fixes #286 
#### What's this PR do?

Previously the cart state stored a seat count for each module. This refactors the code to store the seat count for the cart per course instead.
#### Where should the reviewer start?

portal/util.py
#### How should this be manually tested?

Things should work like they did before, except:
- In the Stripe checkout widget you should see `course(s)` instead of `item(s)`
- The cart panel will now show a list of courses, not modules. Module titles will be added back in #293
#### What gif best describes this PR or how it makes you feel?

http://i.giphy.com/hB5fuWbnoioV2.gif
