### PR TITLE
Added permissions API

### DIFF
--- a/portal/permissions.py
+++ b/portal/permissions.py
@@ -17,6 +17,8 @@ from rest_framework.permissions import BasePermission
 log = logging.getLogger(__name__)
 
 
+# Note that the codename for each permission is exposed in our REST API, in order
+# to tell the UI what changes to make based on user permissions.
 EDIT_OWN_CONTENT = (
     'edit_own_content',
     'Can edit descriptive content for a course and related modules'
@@ -105,7 +107,7 @@ class AuthorizationHelpers(object):
         Returns:
             bool: True if the user owns the course
         """
-        return user.courses_owned.filter(id=course.id).exists()
+        return course.owners.filter(id=user.id).exists()
 
     @classmethod
     def has_edit_own_price_perm(cls, course, user):

--- a/portal/permissions_test.py
+++ b/portal/permissions_test.py
@@ -5,7 +5,7 @@ Tests about permissions
 from __future__ import unicode_literals
 
 from django.test import TestCase
-from django.contrib.auth.models import User, Group
+from django.contrib.auth.models import User, Group, AnonymousUser
 
 from portal.factories import CourseFactory, ModuleFactory
 from portal.permissions import (
@@ -93,6 +93,14 @@ class PermissionsTests(TestCase):
         assert not AuthorizationHelpers.is_owner(course, user)
         course.owners.add(user)
         assert AuthorizationHelpers.is_owner(course, user)
+
+    def test_is_owner_anonymous(self):
+        """
+        Assert that is_owner returns false if user is anonymous.
+        """
+        user = AnonymousUser()
+        course = CourseFactory.create()
+        assert not AuthorizationHelpers.is_owner(course, user)
 
     def test_edit_content_perm(self):
         """

--- a/portal/urls.py
+++ b/portal/urls.py
@@ -8,6 +8,7 @@ from portal.views.activation import activate_view
 from portal.views.checkout_api import CheckoutView
 from portal.views.login import LoginView, logout_view
 from portal.views.course_api import CourseListView, CourseDetailView
+from portal.views.permissions_api import course_permissions_view
 from portal.views.registration import register_view
 from portal.views.webhooks import WebhooksCCXConView
 from portal.views.webpack import index_view
@@ -19,6 +20,9 @@ urlpatterns = (
     url(r'^api/v1/logout/$', logout_view, name='logout'),
     url(r'^api/v1/courses/$', CourseListView.as_view(), name='course-list'),
     url(r'^api/v1/courses/(?P<uuid>[-\w]+)/$', CourseDetailView.as_view(), name='course-detail'),
+    url(r'^api/v1/course_permissions/(?P<uuid>[-\w]+)/$',
+        course_permissions_view,
+        name='course-permissions'),
     url(r'^api/v1/register/$', register_view, name='register'),
     url(r'^api/v1/activate/$', activate_view, name='activate'),
     url(r'^api/v1/checkout/$', CheckoutView.as_view(), name='checkout'),

--- a/portal/views/activation.py
+++ b/portal/views/activation.py
@@ -4,13 +4,15 @@ View for account activation.
 from __future__ import unicode_literals
 
 from rest_framework.decorators import api_view
-from rest_framework.response import Response
 from rest_framework.exceptions import ValidationError
+from rest_framework.decorators import permission_classes
+from rest_framework.response import Response
 
 from portal.models import UserInfo
 
 
 @api_view(["POST"])
+@permission_classes([])
 def activate_view(request):
     """
     Register token to activate user

--- a/portal/views/login.py
+++ b/portal/views/login.py
@@ -4,7 +4,7 @@ Views for login/logout.
 from __future__ import unicode_literals
 
 from django.contrib.auth import authenticate, login, logout
-from rest_framework.decorators import api_view
+from rest_framework.decorators import api_view, permission_classes
 from rest_framework.response import Response
 from rest_framework.views import APIView
 from rest_framework.exceptions import ValidationError
@@ -52,6 +52,7 @@ class LoginView(APIView):
 
 
 @api_view(["POST"])
+@permission_classes([])
 def logout_view(request):
     """
     View to logout user.

--- a/portal/views/permissions_api.py
+++ b/portal/views/permissions_api.py
@@ -1,0 +1,45 @@
+"""
+REST API for getting permissions
+"""
+
+from __future__ import unicode_literals
+
+from django.http.response import Http404
+from rest_framework.decorators import api_view
+from rest_framework.response import Response
+
+from portal.permissions import (
+    AuthorizationHelpers,
+    EDIT_OWN_PRICE,
+    EDIT_OWN_CONTENT,
+    EDIT_OWN_LIVENESS,
+)
+
+
+@api_view(["GET"])
+def course_permissions_view(request, uuid):
+    """
+    Returns a list of permissions and other information to adjust UI in client.
+
+    Args:
+        request (rest_framework.request.Request): The REST request
+        uuid (str): The course UUID
+    Returns:
+        rest_framework.request.Response: The REST response
+    """
+    course = AuthorizationHelpers.get_course(uuid)
+    if course is None:
+        raise Http404
+
+    return Response(data={
+        EDIT_OWN_PRICE[0]: AuthorizationHelpers.has_edit_own_price_perm(
+            course, request.user
+        ),
+        EDIT_OWN_CONTENT[0]: AuthorizationHelpers.has_edit_own_content_perm(
+            course, request.user
+        ),
+        EDIT_OWN_LIVENESS[0]: AuthorizationHelpers.has_edit_own_liveness_perm(
+            course, request.user
+        ),
+        "is_owner": AuthorizationHelpers.is_owner(course, request.user)
+    })

--- a/portal/views/permissions_api_test.py
+++ b/portal/views/permissions_api_test.py
@@ -1,0 +1,86 @@
+"""
+Permissions API tests
+"""
+
+from __future__ import unicode_literals
+import json
+from itertools import product
+from mock import patch
+from six import get_function_code
+
+from django.contrib.auth.models import User
+from django.core.urlresolvers import reverse
+from django.test import TestCase
+
+from portal.factories import CourseFactory, ModuleFactory
+from portal.permissions import (
+    EDIT_OWN_CONTENT,
+    EDIT_OWN_LIVENESS,
+    EDIT_OWN_PRICE,
+    AuthorizationHelpers as Helpers,
+)
+
+
+class PermissionsAPITests(TestCase):
+    """
+    Permission API tests
+    """
+
+    def test_permissions(self):
+        """
+        Test all possible combinations of permissions.
+        """
+        User.objects.create_user(username="user", password="pass")
+        self.client.login(username="user", password="pass")
+
+        course = CourseFactory.create(live=True)
+        ModuleFactory.create(price_without_tax=3, course=course)
+        assert course.is_available_for_purchase
+
+        def assert_permissions(edit_content, edit_liveness, edit_price, is_owner):
+            """Mock and assert these set of permissions"""
+
+            @patch.object(Helpers, 'is_owner', return_value=is_owner)
+            @patch.object(Helpers, 'has_edit_own_content_perm', return_value=edit_content)
+            @patch.object(Helpers, 'has_edit_own_liveness_perm', return_value=edit_liveness)
+            @patch.object(Helpers, 'has_edit_own_price_perm', return_value=edit_price)
+            def run_assert_permissions(*args):  # pylint: disable=unused-argument
+                """Something to attach our patch objects to so we don't indent each time"""
+                resp = self.client.get(
+                    reverse('course-permissions', kwargs={"uuid": course.uuid})
+                )
+                assert resp.status_code == 200, resp.content.decode('utf-8')
+                result = json.loads(resp.content.decode('utf-8'))
+                assert result == {
+                    "is_owner": is_owner,
+                    EDIT_OWN_CONTENT[0]: edit_content,
+                    EDIT_OWN_PRICE[0]: edit_price,
+                    EDIT_OWN_LIVENESS[0]: edit_liveness,
+                }
+            run_assert_permissions()
+
+        num_args = get_function_code(assert_permissions).co_argcount  # pylint: disable=no-member
+        args = [(True, False)] * num_args
+        for tup in product(*args):
+            assert_permissions(*tup)
+
+    def test_no_course(self):
+        """
+        If course is missing we should return a 404.
+        """
+        User.objects.create_user(username="user", password="pass")
+        self.client.login(username="user", password="pass")
+
+        resp = self.client.get(reverse('course-permissions', kwargs={'uuid': 'missing'}))
+        assert resp.status_code == 404, resp.content.decode('utf-8')
+
+    def test_not_logged_in(self):
+        """
+        If the user is not logged in, return a 403.
+        """
+        course = CourseFactory.create(live=True)
+        ModuleFactory.create(price_without_tax=3, course=course)
+        assert course.is_available_for_purchase
+
+        resp = self.client.get(reverse('course-permissions', kwargs={'uuid': course.uuid}))
+        assert resp.status_code == 403, resp.content.decode('utf-8')

--- a/portal/views/registration.py
+++ b/portal/views/registration.py
@@ -10,7 +10,7 @@ from django.conf import settings
 from django.db import transaction
 from django.contrib.auth.models import User
 from django.core.mail import send_mail
-from rest_framework.decorators import api_view
+from rest_framework.decorators import api_view, permission_classes
 from rest_framework.response import Response
 from rest_framework.exceptions import ValidationError
 
@@ -18,6 +18,7 @@ from portal.models import UserInfo
 
 
 @api_view(["POST"])
+@permission_classes([])
 def register_view(request):
     """
     Register a new user.

--- a/teachersportal/settings.py
+++ b/teachersportal/settings.py
@@ -296,3 +296,10 @@ HEALTH_CHECK = ['POSTGRES']
 
 GA_TRACKING_ID = get_var("GA_TRACKING_ID", "")
 REACT_GA_DEBUG = get_var("REACT_GA_DEBUG", False)
+
+# Configure REST framework
+REST_FRAMEWORK = {
+    'DEFAULT_PERMISSION_CLASSES': (
+        'rest_framework.permissions.IsAuthenticated',
+    )
+}


### PR DESCRIPTION
#### What are the relevant tickets?

Fixes #307 
#### What's this PR do?

Adds a REST API at `/api/v1/course_permissions/course_uuid/` to get permissions of a course.
#### Where should the reviewer start?

portal/views/permissions_api.py
#### How should this be manually tested?

Get a course UUID and go to the endpoint URL `/api/v1/course_permissions/course_uuid/` replacing `course_uuid` with your UUID. You should see a mapping of bool values depending on the permissions you have. As of right now these should all be false since there's no way to become an instructor yet, or to mark yourself as being a course owner.
