### PR TITLE
Remove content tab.

### DIFF
--- a/static/js/components/CourseTabs.js
+++ b/static/js/components/CourseTabs.js
@@ -23,19 +23,6 @@ class CourseTabs extends React.Component {
             <Tab label="About" id="about" className="tab" onActive={this.handleActive}>
                 <AboutTab content={course.info.overview} />
             </Tab>
-            <Tab label="Content" id="content" className="tab" onActive={this.handleActive}>
-                <ChapterTab
-                  selectable={false}
-                  fixedHeader={true}
-                  fixedFooter={true}
-                  stripedRows={false}
-                  showRowHover={true}
-                  deselectOnClickaway={true}
-                  height={'auto'}
-                  course={course}
-                  courseList={courseList}
-                 />
-            </Tab>
             <Tab label="Buy" id="buy" className="tab" onActive={this.handleActive}>
                 <BuyTabContainer
                   selectable={true}


### PR DESCRIPTION
#### What are the relevant tickets?

Fixes #301 
Fixes #309 
#### What's this PR do?

Removes the content tab. Now we only have a pricing tab and an about tab.
#### Where should the reviewer start?

CourseTabs.js
#### How should this be manually tested?

Look at it.
#### Any background context you want to provide?

No.
#### Screenshots (if appropriate)

![no-content-tab](https://cloud.githubusercontent.com/assets/3853/12900598/302e7cd0-ce85-11e5-8bcf-cde644a25dff.png)
#### What gif best describes this PR or how it makes you feel?

![](http://s.mlkshk-cdn.com/r/17GK7.jpg)
