### PR TITLE
Implemented checks to enforce permissions for checkout API

### DIFF
--- a/portal/permissions.py
+++ b/portal/permissions.py
@@ -110,7 +110,7 @@ class AuthorizationHelpers(object):
         return course.owners.filter(id=user.id).exists()
 
     @classmethod
-    def has_edit_own_price_perm(cls, course, user):
+    def can_edit_own_price(cls, course, user):
         """
         Does user have permission to edit their own course's price?
 
@@ -128,7 +128,7 @@ class AuthorizationHelpers(object):
         )
 
     @classmethod
-    def has_edit_own_content_perm(cls, course, user):
+    def can_edit_own_content(cls, course, user):
         """
         Does user have permission to edit their own course's descriptive content?
 
@@ -146,7 +146,7 @@ class AuthorizationHelpers(object):
         )
 
     @classmethod
-    def has_edit_own_liveness_perm(cls, course, user):
+    def can_edit_own_liveness(cls, course, user):
         """
         Does user have permission to edit their own course's live flag?
 
@@ -162,3 +162,17 @@ class AuthorizationHelpers(object):
             user.has_perm("portal.{}".format(EDIT_OWN_LIVENESS[0])) and
             cls.is_owner(course, user)
         )
+
+    @classmethod
+    def can_purchase_course(cls, course, user):
+        """
+        Does user have the ability to purchase a course?
+
+        Args:
+            course (Course): A course
+            user (django.contrib.auth.models.User): A User
+
+        Returns:
+            bool: True if user has permission to buy a course
+        """
+        return not cls.is_owner(course, user) and course.is_available_for_purchase

--- a/portal/views/checkout_api.py
+++ b/portal/views/checkout_api.py
@@ -74,17 +74,14 @@ class CheckoutView(APIView):
                 log.error("Couldn't connect to ccxcon. Reason: %s", result.content)
         return errors
 
-    @staticmethod
-    def validate_data(data):
+    def validate_data(self):
         """
         Validates incoming request data.
-
-        Args:
-            request.data: Data from incoming request.
 
         Returns:
             (string, dict): stripe token and cart information.
         """
+        data = self.request.data
         try:
             token = str(data['token'])
             cart = data['cart']
@@ -98,7 +95,7 @@ class CheckoutView(APIView):
             raise ValidationError("Cart must be a list of items")
         if len(cart) == 0:
             raise ValidationError("Cannot checkout an empty cart")
-        validate_cart(cart)
+        validate_cart(cart, self.request.user)
 
         total = calculate_cart_subtotal(cart)
         if get_cents(total) != get_cents(estimated_total):
@@ -120,7 +117,7 @@ class CheckoutView(APIView):
         Returns:
             rest_framework.response.Response
         """
-        token, cart = self.validate_data(request.data)
+        token, cart = self.validate_data()
 
         with transaction.atomic():
             order = create_order(cart, request.user)

--- a/portal/views/permissions_api.py
+++ b/portal/views/permissions_api.py
@@ -32,13 +32,13 @@ def course_permissions_view(request, uuid):
         raise Http404
 
     return Response(data={
-        EDIT_OWN_PRICE[0]: AuthorizationHelpers.has_edit_own_price_perm(
+        EDIT_OWN_PRICE[0]: AuthorizationHelpers.can_edit_own_price(
             course, request.user
         ),
-        EDIT_OWN_CONTENT[0]: AuthorizationHelpers.has_edit_own_content_perm(
+        EDIT_OWN_CONTENT[0]: AuthorizationHelpers.can_edit_own_content(
             course, request.user
         ),
-        EDIT_OWN_LIVENESS[0]: AuthorizationHelpers.has_edit_own_liveness_perm(
+        EDIT_OWN_LIVENESS[0]: AuthorizationHelpers.can_edit_own_liveness(
             course, request.user
         ),
         "is_owner": AuthorizationHelpers.is_owner(course, request.user)

--- a/portal/views/permissions_api_test.py
+++ b/portal/views/permissions_api_test.py
@@ -41,9 +41,9 @@ class PermissionsAPITests(TestCase):
             """Mock and assert these set of permissions"""
 
             @patch.object(Helpers, 'is_owner', return_value=is_owner)
-            @patch.object(Helpers, 'has_edit_own_content_perm', return_value=edit_content)
-            @patch.object(Helpers, 'has_edit_own_liveness_perm', return_value=edit_liveness)
-            @patch.object(Helpers, 'has_edit_own_price_perm', return_value=edit_price)
+            @patch.object(Helpers, 'can_edit_own_content', return_value=edit_content)
+            @patch.object(Helpers, 'can_edit_own_liveness', return_value=edit_liveness)
+            @patch.object(Helpers, 'can_edit_own_price', return_value=edit_price)
             def run_assert_permissions(*args):  # pylint: disable=unused-argument
                 """Something to attach our patch objects to so we don't indent each time"""
                 resp = self.client.get(


### PR DESCRIPTION
#### What are the relevant tickets?

Fixes #306
Refs #304 
#### What's this PR do?

Restricts a user who is an owner of a course from purchasing that course. This is only done in the REST API, the UI is currently unchanged. See #312 for that
#### Where should the reviewer start?

portal/util.py
#### How should this be manually tested?

In the shell, add your user as an owner of the course: `user.courses_owned.add(course)`. Then try to purchase a course. You should get a 400 and an error message which explains that you can't purchase a course you own.
