### PR TITLE
Implemented PATCH for course API

### DIFF
--- a/portal/migrations/0009_no_null_for_description.py
+++ b/portal/migrations/0009_no_null_for_description.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+# pylint: skip-file
+
+def remove_none(apps, schema_editor):
+    Course = apps.get_model("portal", "Course")
+    for course in Course.objects.filter(description=None).all():
+        course.description = ""
+        course.save()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('portal', '0008_see_own_not_live'),
+    ]
+
+    operations = [
+        # Reverse migration does nothing here
+        migrations.RunPython(remove_none, lambda *args: None),
+        migrations.AlterField(
+            model_name='course',
+            name='description',
+            field=models.TextField(default=None, blank=True),
+            preserve_default=False,
+        ),
+    ]

--- a/portal/models.py
+++ b/portal/models.py
@@ -47,7 +47,7 @@ class Course(models.Model):
     """
     uuid = TextField()
     title = TextField()
-    description = TextField(blank=True, null=True)
+    description = TextField(blank=True)
     live = BooleanField()
     created_at = DateTimeField(auto_now_add=True, blank=True)
     modified_at = DateTimeField(auto_now=True, blank=True)

--- a/portal/views/base.py
+++ b/portal/views/base.py
@@ -83,10 +83,5 @@ class CourseTests(TestCase):
         """
         Create a course and module which aren't live.
         """
-        self.course = CourseFactory.create(
-            description=None,
-            live=False,
-        )
-        self.module = ModuleFactory.create(
-            course=self.course,
-        )
+        self.course = CourseFactory.create(live=False)
+        self.module = ModuleFactory.create(course=self.course)

--- a/portal/views/course_api.py
+++ b/portal/views/course_api.py
@@ -3,17 +3,22 @@ Views for course availability listing.
 """
 from __future__ import unicode_literals
 
+from decimal import Decimal, DecimalException
 import logging
 import json
 from six.moves.urllib.parse import urlparse, urlunparse  # pylint: disable=import-error
+from six import string_types
 
 from django.conf import settings
 from django.http.response import Http404
 from oauthlib.oauth2 import BackendApplicationClient
 from requests_oauthlib import OAuth2Session
+from rest_framework.exceptions import ValidationError
 from rest_framework.generics import ListAPIView, RetrieveAPIView
+from rest_framework.response import Response
 from rest_framework.status import HTTP_200_OK
 
+from portal.models import Module
 from portal.permissions import AuthorizationHelpers
 from portal.serializers import (
     CourseSerializer,
@@ -198,3 +203,115 @@ class CourseDetailView(RetrieveAPIView):
                 for uuid, module in modules_info.items()
             }
         )
+
+    # This method is a mammoth due to how much per-field validation we need to do
+    # pylint: disable=too-many-locals, too-many-branches, too-many-statements
+    def patch(self, request, *args, **kwargs):  # pylint: disable=unused-argument
+        """
+        Take PATCH requests, check permissions, and alter state based on them.
+        """
+        uuid = self.kwargs['uuid']
+        data = request.data
+        user = request.user
+        # We shouldn't save any data until all validation checks out
+        course_modified = False
+        course = AuthorizationHelpers.get_course(uuid, user)
+        if course is None:
+            raise Http404
+
+        if "live" in data:
+            live = data['live']
+            if not isinstance(live, bool):
+                raise ValidationError("live must be a bool")
+            if not AuthorizationHelpers.can_edit_own_liveness(course, user):
+                raise ValidationError("User doesn't have permission to edit course liveness")
+
+            course.live = live
+            course_modified = True
+
+        if "title" in data:
+            title = data['title']
+            if not isinstance(title, string_types) or title == '':
+                raise ValidationError("title must be a non-empty string")
+            if not AuthorizationHelpers.can_edit_own_content(course, user):
+                raise ValidationError(
+                    "User doesn't have permission to edit course descriptions or titles"
+                )
+
+            course.title = title
+            course_modified = True
+
+        if "description" in data:
+            description = data['description']
+            if not isinstance(description, string_types):
+                raise ValidationError("description must be a string")
+            if not AuthorizationHelpers.can_edit_own_content(course, user):
+                raise ValidationError(
+                    "User doesn't have permission to edit course descriptions or titles"
+                )
+
+            course.description = description
+            course_modified = True
+
+        modules_to_save = {}
+        if "modules" in data:
+            if not isinstance(data['modules'], list):
+                raise ValidationError("modules must be a list of modules")
+
+            for module_data in data['modules']:
+                if not isinstance(module_data, dict):
+                    raise ValidationError("Each module must be an object")
+                if 'uuid' not in module_data:
+                    raise ValidationError("Missing key uuid")
+                if module_data['uuid'] in modules_to_save:
+                    raise ValidationError("Duplicate module")
+
+                try:
+                    # We've already checked permissions for course above
+                    # so this is a simple object lookup
+                    module = Module.objects.get(
+                        uuid=module_data['uuid'],
+                        course=course
+                    )
+                except Module.DoesNotExist:
+                    raise ValidationError(
+                        "Unable to find module {uuid}".format(uuid=module_data['uuid'])
+                    )
+
+                if 'title' in module_data:
+                    title = module_data['title']
+                    if not isinstance(title, string_types) or title == '':
+                        raise ValidationError("title must be a non-empty string")
+                    if not AuthorizationHelpers.can_edit_own_content(course, user):
+                        raise ValidationError(
+                            "User doesn't have permission to edit course descriptions or titles"
+                        )
+
+                    module.title = title
+                    modules_to_save[module.uuid] = module
+
+                if 'price_without_tax' in module_data:
+                    price_without_tax = module_data['price_without_tax']
+                    if price_without_tax is not None:
+                        if not isinstance(price_without_tax, string_types):
+                            raise ValidationError('price_without_tax must be a string')
+                        try:
+                            price_without_tax = Decimal(price_without_tax)
+                        except DecimalException:
+                            raise ValidationError('price_without_tax is not a valid number')
+                        if not price_without_tax.is_finite():
+                            raise ValidationError('price_without_tax is not a valid number')
+                        if price_without_tax < 0:
+                            raise ValidationError('price_without_tax is not a valid number')
+
+                    if not AuthorizationHelpers.can_edit_own_price(course, user):
+                        raise ValidationError("User doesn't have permission to edit module price")
+
+                    module.price_without_tax = price_without_tax
+                    modules_to_save[module.uuid] = module
+
+        if course_modified:
+            course.save()
+        for module in modules_to_save.values():
+            module.save()
+        return Response(status=200)


### PR DESCRIPTION
#### What are the relevant tickets?

Fixes #305 
Fixes #304 

Rebased on #352
#### What's this PR do?

Implements PATCH for the course detail API, which allows the user to edit:
- course title
- course description
- course liveness
- module title
- module price

The user must have the right permissions (ie, be an instructor) and must be an owner of the course.
#### Where should the reviewer start?

portal/views/course_api.py
#### How should this be manually tested?

Make yourself an instructor (in the django shell: `user.groups.add(Group.objects.get(name="Instructor"))`), then attempt to patch the five fields shown above. `modules` is used to patch modules within a course. All other fields are ignored.
#### What gif best describes this PR or how it makes you feel?

![](http://i.giphy.com/r2m3B9buvHJ4Y.gif)
