### PR TITLE
Made courses which are not live visible to instructors, and added a live flag

### DIFF
--- a/portal/migrations/0002_add_instance.py
+++ b/portal/migrations/0002_add_instance.py
@@ -12,6 +12,11 @@ def add_default_backinginstance(apps, schema_editor):
     BackingInstance.objects.create(instance_url=EXAMPLE_URL)
 
 
+def reverse_add_default_backinginstance(apps, schema_editor):
+    BackingInstance = apps.get_model('portal', 'BackingInstance')
+    BackingInstance.objects.filter(instance_url=EXAMPLE_URL).all().delete()
+
+
 def populate_default_backinginstance(apps, schema_editor):
     BackingInstance = apps.get_model("portal", "BackingInstance")
     Course = apps.get_model("portal", "Course")
@@ -20,6 +25,11 @@ def populate_default_backinginstance(apps, schema_editor):
     for course in Course.objects.all():
         course.instance = instance
         course.save()
+
+
+def reverse_populate_default_backinginstance(apps, schema_editor):
+    BackingInstance = apps.get_model("portal", "BackingInstance")
+    BackingInstance.objects.get(instance_url=EXAMPLE_URL).course_set.all().delete()
 
 
 class Migration(migrations.Migration):
@@ -36,13 +46,13 @@ class Migration(migrations.Migration):
                 ('instance_url', models.TextField()),
             ],
         ),
-        migrations.RunPython(add_default_backinginstance),
+        migrations.RunPython(add_default_backinginstance, reverse_add_default_backinginstance),
         migrations.AddField(
             model_name='course',
             name='instance',
             field=models.ForeignKey(to='portal.BackingInstance', null=True),
         ),
-        migrations.RunPython(populate_default_backinginstance),
+        migrations.RunPython(populate_default_backinginstance, reverse_populate_default_backinginstance),
         migrations.AlterField(
             model_name='course',
             name='instance',

--- a/portal/migrations/0004_groups.py
+++ b/portal/migrations/0004_groups.py
@@ -6,11 +6,15 @@ from django.db import migrations, models
 # pylint: skip-file
 
 
-def populate_groups(apps, schema_editor):
+def add_instructor_group(apps, schema_editor):
     Group = apps.get_model("auth", "Group")
-    Group.objects.create(
+    Group.objects.get_or_create(
         name='Instructor'
     )
+
+def remove_instructor_group(apps, schema_editor):
+    Group = apps.get_model("auth", "Group")
+    Group.objects.filter(name='Instructor').delete()
 
 
 class Migration(migrations.Migration):
@@ -20,5 +24,5 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.RunPython(populate_groups),
+        migrations.RunPython(add_instructor_group, remove_instructor_group),
     ]

--- a/portal/migrations/0006_assign_permissions.py
+++ b/portal/migrations/0006_assign_permissions.py
@@ -22,7 +22,9 @@ def add_permissions_to_groups(apps, schema_editor, with_create_permissions=True)
     for codename in ('edit_own_content', 'edit_own_liveness', 'edit_own_price'):
         try:
             perm = Permission.objects.get(
-                codename=codename, content_type__app_label='portal')
+                codename=codename,
+                content_type__app_label='portal'
+            )
         except Permission.DoesNotExist:
             if with_create_permissions:
                 # Manually run create_permissions
@@ -38,6 +40,20 @@ def add_permissions_to_groups(apps, schema_editor, with_create_permissions=True)
         instructor.permissions.add(perm)
 
 
+def reverse_add_permissions_to_groups(apps, schema_editor):
+    """
+    Important: the permission will get recreated in the post_migrate hook
+    so the reverse migration won't work fully. However it won't be attached
+    to the group or users anymore.
+    """
+    Permission = apps.get_model("auth", "Permission")
+    for codename in ('edit_own_content', 'edit_own_liveness', 'edit_own_price'):
+        Permission.objects.get(
+            codename=codename,
+            content_type__app_label='portal'
+        ).delete()
+
+
 class Migration(migrations.Migration):
 
     dependencies = [
@@ -46,5 +62,5 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.RunPython(add_permissions_to_groups)
+        migrations.RunPython(add_permissions_to_groups, reverse_add_permissions_to_groups)
     ]

--- a/portal/migrations/0008_see_own_not_live.py
+++ b/portal/migrations/0008_see_own_not_live.py
@@ -1,0 +1,60 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+# pylint: skip-file
+
+
+def add_see_own_not_live(apps, schema_editor, with_create_permissions=True):
+    """
+    Adapted from comment in https://code.djangoproject.com/ticket/23422
+    """
+    Group = apps.get_model("auth", "Group")
+    instructor = Group.objects.get(
+        name='Instructor'
+    )
+
+    Permission = apps.get_model("auth", "Permission")
+    codename = 'see_own_not_live'
+    try:
+        perm = Permission.objects.get(
+            codename=codename, content_type__app_label='portal')
+    except Permission.DoesNotExist:
+        if with_create_permissions:
+            # Manually run create_permissions
+            from django.contrib.auth.management import create_permissions
+            assert not getattr(apps, 'models_module', None)
+            apps.models_module = True
+            create_permissions(apps, verbosity=0)
+            apps.models_module = None
+            return add_see_own_not_live(
+                apps, schema_editor, with_create_permissions=False)
+        else:
+            raise
+    instructor.permissions.add(perm)
+
+
+def reverse_add_see_own_not_live(apps, schema_editor):
+    """
+    Important: the permission will get recreated in the post_migrate hook
+    so the reverse migration won't work fully. However it won't be attached
+    to the group or users anymore.
+    """
+    Permission = apps.get_model("auth", "Permission")
+    Permission.objects.get(codename='see_own_not_live').delete()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('portal', '0007_course_owners'),
+    ]
+
+    operations = [
+        migrations.AlterModelOptions(
+            name='course',
+            options={'ordering': ('created_at',), 'permissions': (('edit_own_content', 'Can edit descriptive content for a course and related modules'), ('edit_own_liveness', 'Can mark a course live or not live'), ('see_own_not_live', 'Can see courses which are not live'))},
+        ),
+        migrations.RunPython(add_see_own_not_live, reverse_add_see_own_not_live),
+    ]

--- a/portal/models.py
+++ b/portal/models.py
@@ -24,6 +24,7 @@ from portal.permissions import (
     EDIT_OWN_CONTENT,
     EDIT_OWN_LIVENESS,
     EDIT_OWN_PRICE,
+    SEE_OWN_NOT_LIVE,
 )
 
 
@@ -71,6 +72,7 @@ class Course(models.Model):
         permissions = (
             EDIT_OWN_CONTENT,
             EDIT_OWN_LIVENESS,
+            SEE_OWN_NOT_LIVE,
         )
 
 

--- a/portal/serializers.py
+++ b/portal/serializers.py
@@ -6,6 +6,7 @@ from __future__ import unicode_literals
 
 from rest_framework.serializers import (
     Serializer,
+    BooleanField,
     CharField,
     DictField,
     ListField,
@@ -20,6 +21,7 @@ class CourseSerializer(Serializer):
     description = CharField()
     uuid = CharField()
     info = DictField()
+    live = BooleanField()
     modules = ListField()
 
 

--- a/portal/util.py
+++ b/portal/util.py
@@ -42,6 +42,7 @@ def course_as_dict(course, course_info=None, modules_info=None):
         "uuid": course.uuid,
         "info": course_info,
         "modules": modules,
+        "live": course.live
     }
 
 
@@ -129,7 +130,7 @@ def validate_cart(cart, user):
         if course_uuid in courses_in_cart:
             log.debug("Duplicate course %s in cart", course_uuid)
             raise ValidationError("Duplicate course in cart")
-        course = AuthorizationHelpers.get_course(course_uuid)
+        course = AuthorizationHelpers.get_course(course_uuid, user)
         if course is None:
             raise ValidationError("One or more courses are unavailable")
 

--- a/portal/util_test.py
+++ b/portal/util_test.py
@@ -57,7 +57,8 @@ class CourseUtilTests(CourseTests):
             "info": {
                 "type": "course"
             },
-            "modules": [expected_module]
+            "modules": [expected_module],
+            "live": self.course.live
         }
 
     def test_live_availability(self):

--- a/portal/views/course_api.py
+++ b/portal/views/course_api.py
@@ -159,7 +159,7 @@ class CourseListView(ListAPIView):
 
         return [
             course_as_dict(course)
-            for course in AuthorizationHelpers.get_courses()
+            for course in AuthorizationHelpers.get_courses(self.request.user)
         ]
 
 
@@ -184,7 +184,7 @@ class CourseDetailView(RetrieveAPIView):
         Looks up information for a course from CCXCon and Course model.
         """
         uuid = self.kwargs['uuid']
-        course = AuthorizationHelpers.get_course(uuid)
+        course = AuthorizationHelpers.get_course(uuid, self.request.user)
         if course is None:
             raise Http404
 

--- a/portal/views/permissions_api.py
+++ b/portal/views/permissions_api.py
@@ -13,6 +13,7 @@ from portal.permissions import (
     EDIT_OWN_PRICE,
     EDIT_OWN_CONTENT,
     EDIT_OWN_LIVENESS,
+    SEE_OWN_NOT_LIVE,
 )
 
 
@@ -27,7 +28,7 @@ def course_permissions_view(request, uuid):
     Returns:
         rest_framework.request.Response: The REST response
     """
-    course = AuthorizationHelpers.get_course(uuid)
+    course = AuthorizationHelpers.get_course(uuid, request.user)
     if course is None:
         raise Http404
 
@@ -39,6 +40,9 @@ def course_permissions_view(request, uuid):
             course, request.user
         ),
         EDIT_OWN_LIVENESS[0]: AuthorizationHelpers.can_edit_own_liveness(
+            course, request.user
+        ),
+        SEE_OWN_NOT_LIVE[0]: AuthorizationHelpers.can_see_own_not_live(
             course, request.user
         ),
         "is_owner": AuthorizationHelpers.is_owner(course, request.user)

--- a/portal/views/permissions_api_test.py
+++ b/portal/views/permissions_api_test.py
@@ -17,6 +17,7 @@ from portal.permissions import (
     EDIT_OWN_CONTENT,
     EDIT_OWN_LIVENESS,
     EDIT_OWN_PRICE,
+    SEE_OWN_NOT_LIVE,
     AuthorizationHelpers as Helpers,
 )
 
@@ -37,13 +38,14 @@ class PermissionsAPITests(TestCase):
         ModuleFactory.create(price_without_tax=3, course=course)
         assert course.is_available_for_purchase
 
-        def assert_permissions(edit_content, edit_liveness, edit_price, is_owner):
+        def assert_permissions(edit_content, edit_liveness, edit_price, is_owner, see_not_live):
             """Mock and assert these set of permissions"""
 
             @patch.object(Helpers, 'is_owner', return_value=is_owner)
             @patch.object(Helpers, 'can_edit_own_content', return_value=edit_content)
             @patch.object(Helpers, 'can_edit_own_liveness', return_value=edit_liveness)
             @patch.object(Helpers, 'can_edit_own_price', return_value=edit_price)
+            @patch.object(Helpers, 'can_see_own_not_live', return_value=see_not_live)
             def run_assert_permissions(*args):  # pylint: disable=unused-argument
                 """Something to attach our patch objects to so we don't indent each time"""
                 resp = self.client.get(
@@ -56,6 +58,7 @@ class PermissionsAPITests(TestCase):
                     EDIT_OWN_CONTENT[0]: edit_content,
                     EDIT_OWN_PRICE[0]: edit_price,
                     EDIT_OWN_LIVENESS[0]: edit_liveness,
+                    SEE_OWN_NOT_LIVE[0]: see_not_live,
                 }
             run_assert_permissions()
 


### PR DESCRIPTION
#### What are the relevant tickets?

Fixes #335 
#### What's this PR do?
- Adds `live` boolean to the course list and detail API
- Makes courses accessible if they are not live, if the user has a special permission to see not live courses, and if they are the owner of the course
#### Where should the reviewer start?

portal/course_api.py
#### How should this be manually tested?
- Run migrations
- Setup a course so that it is not live
- Create a user. In the Django shell make this user an instructor: `user.groups.add(Group.objects.get(name="Instructor"))`
- Also make this user an owner of the course: `user.courses_owned.add(course)`
- When logged out, go to the course list page. You should see only live courses.
- Log in as the instructor and you should now additionally see the course which is not live.
- Also verify that the course detail page shows up correctly for the instructor.
- And finally go to `/api/v1/courses/uuid/` where `uuid` is your course uuid. You should see a field `live` which is `false`.
#### What gif best describes this PR or how it makes you feel?

![](http://i.giphy.com/M2Ml23remyvjq.gif)
