### PR TITLE
Trigger a course fetch when UUID state changes

### DIFF
--- a/static/js/containers/CourseDetailPage.js
+++ b/static/js/containers/CourseDetailPage.js
@@ -8,14 +8,14 @@ import {
   clearInvalidCartItems,
   showSnackBar,
   FETCH_FAILURE,
-  FETCH_SUCCESS,
+  FETCH_SUCCESS
 } from '../actions/index_page';
 import { connect } from 'react-redux';
 
 class CourseDetailPage extends React.Component {
 
   componentDidMount() {
-    this.fetchCourse.call(this);
+    this.fetchCourse.call(this, true);
     this.handleError.call(this);
   }
 
@@ -24,7 +24,9 @@ class CourseDetailPage extends React.Component {
     this.handleError.call(this);
   }
 
-  fetchCourse() {
+  // forceFetchCourse will trigger a fetch of the course, regardless
+  // of if it's already been fetched.
+  fetchCourse(forceFetchCourse = false) {
     const {
       course,
       authentication,
@@ -37,7 +39,7 @@ class CourseDetailPage extends React.Component {
     // this component is refreshed before action has a chance to dispatch,
     // but that shouldn't cause any problems
 
-    if (course.courseStatus === undefined) {
+    if (forceFetchCourse || course.courseStatus === undefined) {
       dispatch(fetchCourse(uuid));
     }
     if (course.courseListStatus === undefined) {
@@ -53,7 +55,9 @@ class CourseDetailPage extends React.Component {
     } = this.props;
 
     let detail;
-    if (course.course === undefined) {
+    // We should show the loading page if the course isn't loaded or
+    // if there is an error.
+    if (course.courseStatus !== FETCH_SUCCESS) {
       detail = <div id="course-body">
         <Card id="course-content">
           <LinearProgress mode="indeterminate" size="1" className="progress" />
@@ -75,7 +79,7 @@ class CourseDetailPage extends React.Component {
 
 
   handleError() {
-    const { course, dispatch, authentication } = this.props;
+    const { course, dispatch } = this.props;
 
     let error;
 

--- a/static/js/containers/CourseDetailPage_test.js
+++ b/static/js/containers/CourseDetailPage_test.js
@@ -78,11 +78,12 @@ describe('CourseDetailPage', () => {
   });
 
   // Helper function to render CourseDetailPage
-  const renderCourseDetail = () => new Promise(resolve => {
-    const uuid = COURSE_RESPONSE1.uuid;
+  const renderCourseDetail = (postMountFetchResult = COURSE_RESPONSE1) => new Promise(resolve => {
+    const uuid = postMountFetchResult.uuid;
 
     const afterMount = component => {
       resolve(component);
+      store.dispatch(receiveCourseSuccess(postMountFetchResult));
     };
 
     TestUtils.renderIntoDocument(
@@ -104,16 +105,19 @@ describe('CourseDetailPage', () => {
 
     renderCourseDetail().then(component => {
       let node = ReactDOM.findDOMNode(component);
-      assert.ok(!node.innerHTML.includes("ABOUT"));
-      assert.ok(!node.innerHTML.includes("CONTENT"));
-      assert.ok(!node.innerHTML.includes("BUY"));
-      assert.ok(node.innerHTML.includes("Please login for more info"));
+      assert.ok(!node.innerHTML.includes("ABOUT"), 'about missing');
+      assert.ok(!node.innerHTML.includes("CONTENT"), 'content missing');
+      assert.ok(!node.innerHTML.includes("BUY"), 'buy missing');
+      assert.ok(node.innerHTML.includes("Please login for more info"), 'missing login prompt');
 
       done();
     });
   });
 
   it('can check off items in the buy tab', done => {
+    let courseStub = sandbox.stub(api, 'getCourse');
+    courseStub.returns(Promise.resolve(COURSE_RESPONSE1));
+
     // Set up state as if we logged in already
     store.dispatch(loginSuccess({name: "Darth Vader"}));
     store.dispatch(receiveCourseListSuccess(COURSE_LIST));
@@ -151,6 +155,8 @@ describe('CourseDetailPage', () => {
   });
 
   it('can add items to the cart', done => {
+    let courseStub = sandbox.stub(api, 'getCourse');
+    courseStub.returns(Promise.resolve(COURSE_RESPONSE2));
     // Alter state as if we logged in, selected all chapters and updated seat count
     const course1SeatCount = 77;
     const course2SeatCount = 88;
@@ -174,7 +180,7 @@ describe('CourseDetailPage', () => {
 
 
     let node;
-    renderCourseDetail().then(component => {
+    renderCourseDetail(COURSE_RESPONSE2).then(component => {
       node = ReactDOM.findDOMNode(component);
       // Listen for UPDATE_CART_ITEMS and UPDATE_CART_VISIBILITY
       return listenForActions([UPDATE_CART_ITEMS, UPDATE_CART_VISIBILITY], () => {
@@ -205,6 +211,9 @@ describe('CourseDetailPage', () => {
   });
 
   it('shows items in the cart panel', done => {
+    let courseStub = sandbox.stub(api, 'getCourse');
+    courseStub.returns(Promise.resolve(COURSE_RESPONSE1));
+
     const course1SeatCount = 77;
     const course2SeatCount = 88;
     const coursePairs = [{
@@ -262,6 +271,9 @@ describe('CourseDetailPage', () => {
   });
 
   it('can checkout the cart', done => {
+    let courseStub = sandbox.stub(api, 'getCourse');
+    courseStub.returns(Promise.resolve(COURSE_RESPONSE1));
+
     const fakeToken = "FAKE_TOKEN";
 
     const course1SeatCount = 77;
@@ -329,6 +341,9 @@ describe('CourseDetailPage', () => {
   });
 
   it('can checkout the cart with an empty price', done => {
+    let courseStub = sandbox.stub(api, 'getCourse');
+    courseStub.returns(Promise.resolve(COURSE_RESPONSE1));
+
     const zeroPriceCourse = Object.assign(COURSE_RESPONSE1,
       {
         modules: COURSE_RESPONSE1.modules.map(child =>
@@ -372,6 +387,9 @@ describe('CourseDetailPage', () => {
   });
 
   it('fails to checkout', done => {
+    let courseStub = sandbox.stub(api, 'getCourse');
+    courseStub.returns(Promise.resolve(COURSE_RESPONSE1));
+
     const zeroPriceCourse = Object.assign(COURSE_RESPONSE1,
       {
         modules: COURSE_RESPONSE1.modules.map(child =>

--- a/static/js/reducers/index_page.js
+++ b/static/js/reducers/index_page.js
@@ -74,7 +74,10 @@ const INITIAL_COURSE_STATE = {
 };
 
 export const course = handleActions({
-  REQUEST_COURSE: payloadMerge((action) => ({courseStatus: FETCH_PROCESSING})),
+  REQUEST_COURSE: payloadMerge((action) => ({
+    courseStatus: FETCH_PROCESSING,
+    course: undefined
+  })),
   RECEIVE_COURSE_SUCCESS: payloadMerge((action) => ({
     courseStatus: FETCH_SUCCESS,
     course: action.payload.course

--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,7 @@ setenv =
 commands =
     npm install --no-bin-links --prefix {toxinidir}
     node {toxinidir}/node_modules/eslint/bin/eslint.js {toxinidir}/static/js
-    node {toxinidir}/node_modules/mocha/bin/mocha --opts static/js/mocha.opts static/js/global_init.js "static/**/*_test.js"
+    node {toxinidir}/node_modules/mocha/bin/mocha {posargs} --opts static/js/mocha.opts static/js/global_init.js "static/**/*_test.js"
 
 whitelist_externals =
     npm


### PR DESCRIPTION
#### What are the relevant tickets?

Fixes #279 
#### What's this PR do?

When a course detail view component gets a UUID different from the one it's currently displaying, it fetches the new data.
#### Where should the reviewer start?

CourseDetailPage.js
#### How should this be manually tested?

If you can trigger a navigate event from one page to another, that should do it. Might be able to test it through @jamiefolsom's work on cart edit?
#### Any background context you want to provide?

Given Jamie's work on cart edit, we need to support going from a single course detail view to another, not always back out to course list.
#### Screenshots (if appropriate)
#### What gif best describes this PR or how it makes you feel?

![](http://s.mlkshk-cdn.com/r/17J92.gif)
