### PR TITLE
Added back React hot reloading with fixed version of webpack

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,7 +35,7 @@ watch:
     npm install --no-bin-links &&
     npm rebuild node-sass &&
     echo Finished npm install &&
-    node ./node_modules/webpack-dev-server/bin/webpack-dev-server.js --config webpack.config.dev.js -d --content-base ./static --host 0.0.0.0 --port 8076 --progress --inline'
+    node ./node_modules/webpack-dev-server/bin/webpack-dev-server.js --config webpack.config.dev.js -d --content-base ./static --host 0.0.0.0 --port 8076 --progress --inline --hot'
   ports:
     - "8076:8076"
   volumes:

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -4,100 +4,100 @@
   "dependencies": {
     "babel": {
       "version": "6.3.26",
-      "from": "babel@>=6.0.15 <7.0.0",
+      "from": "https://registry.npmjs.org/babel/-/babel-6.3.26.tgz",
       "resolved": "https://registry.npmjs.org/babel/-/babel-6.3.26.tgz"
     },
     "babel-core": {
       "version": "6.4.5",
-      "from": "babel-core@>=6.1.2 <7.0.0",
+      "from": "https://registry.npmjs.org/babel-core/-/babel-core-6.4.5.tgz",
       "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.4.5.tgz",
       "dependencies": {
         "babel-code-frame": {
           "version": "6.3.13",
-          "from": "babel-code-frame@>=6.3.13 <7.0.0",
+          "from": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.3.13.tgz",
           "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.3.13.tgz",
           "dependencies": {
             "chalk": {
               "version": "1.1.1",
-              "from": "chalk@>=1.1.0 <2.0.0",
+              "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
               "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
               "dependencies": {
                 "ansi-styles": {
                   "version": "2.1.0",
-                  "from": "ansi-styles@>=2.1.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
                 },
                 "escape-string-regexp": {
                   "version": "1.0.4",
-                  "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                  "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz",
                   "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz"
                 },
                 "has-ansi": {
                   "version": "2.0.0",
-                  "from": "has-ansi@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                   "dependencies": {
                     "ansi-regex": {
                       "version": "2.0.0",
-                      "from": "ansi-regex@>=2.0.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                     }
                   }
                 },
                 "strip-ansi": {
                   "version": "3.0.0",
-                  "from": "strip-ansi@>=3.0.0 <4.0.0",
+                  "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
                   "dependencies": {
                     "ansi-regex": {
                       "version": "2.0.0",
-                      "from": "ansi-regex@>=2.0.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                     }
                   }
                 },
                 "supports-color": {
                   "version": "2.0.0",
-                  "from": "supports-color@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
                 }
               }
             },
             "esutils": {
               "version": "2.0.2",
-              "from": "esutils@>=2.0.2 <3.0.0",
+              "from": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
               "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
             },
             "js-tokens": {
               "version": "1.0.2",
-              "from": "js-tokens@>=1.0.1 <2.0.0",
+              "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz",
               "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
             },
             "line-numbers": {
               "version": "0.2.0",
-              "from": "line-numbers@>=0.2.0 <0.3.0",
+              "from": "https://registry.npmjs.org/line-numbers/-/line-numbers-0.2.0.tgz",
               "resolved": "https://registry.npmjs.org/line-numbers/-/line-numbers-0.2.0.tgz",
               "dependencies": {
                 "left-pad": {
                   "version": "0.0.3",
-                  "from": "left-pad@0.0.3",
+                  "from": "https://registry.npmjs.org/left-pad/-/left-pad-0.0.3.tgz",
                   "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-0.0.3.tgz"
                 }
               }
             },
             "repeating": {
               "version": "1.1.3",
-              "from": "repeating@>=1.1.3 <2.0.0",
+              "from": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
               "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
               "dependencies": {
                 "is-finite": {
                   "version": "1.0.1",
-                  "from": "is-finite@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
                   "dependencies": {
                     "number-is-nan": {
                       "version": "1.0.0",
-                      "from": "number-is-nan@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
                     }
                   }
@@ -108,17 +108,17 @@
         },
         "babel-generator": {
           "version": "6.4.5",
-          "from": "babel-generator@>=6.4.5 <7.0.0",
+          "from": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.4.5.tgz",
           "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.4.5.tgz",
           "dependencies": {
             "detect-indent": {
               "version": "3.0.1",
-              "from": "detect-indent@>=3.0.1 <4.0.0",
+              "from": "https://registry.npmjs.org/detect-indent/-/detect-indent-3.0.1.tgz",
               "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-3.0.1.tgz",
               "dependencies": {
                 "get-stdin": {
                   "version": "4.0.1",
-                  "from": "get-stdin@>=4.0.1 <5.0.0",
+                  "from": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
                 },
                 "minimist": {
@@ -130,17 +130,17 @@
             },
             "is-integer": {
               "version": "1.0.6",
-              "from": "is-integer@>=1.0.4 <2.0.0",
+              "from": "https://registry.npmjs.org/is-integer/-/is-integer-1.0.6.tgz",
               "resolved": "https://registry.npmjs.org/is-integer/-/is-integer-1.0.6.tgz",
               "dependencies": {
                 "is-finite": {
                   "version": "1.0.1",
-                  "from": "is-finite@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
                   "dependencies": {
                     "number-is-nan": {
                       "version": "1.0.0",
-                      "from": "number-is-nan@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
                     }
                   }
@@ -149,17 +149,17 @@
             },
             "repeating": {
               "version": "1.1.3",
-              "from": "repeating@>=1.1.3 <2.0.0",
+              "from": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
               "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
               "dependencies": {
                 "is-finite": {
                   "version": "1.0.1",
-                  "from": "is-finite@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
                   "dependencies": {
                     "number-is-nan": {
                       "version": "1.0.0",
-                      "from": "number-is-nan@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
                     }
                   }
@@ -168,90 +168,90 @@
             },
             "trim-right": {
               "version": "1.0.1",
-              "from": "trim-right@>=1.0.1 <2.0.0",
+              "from": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
               "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz"
             }
           }
         },
         "babel-helpers": {
           "version": "6.4.5",
-          "from": "babel-helpers@>=6.4.5 <7.0.0",
+          "from": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.4.5.tgz",
           "resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.4.5.tgz"
         },
         "babel-messages": {
           "version": "6.3.18",
-          "from": "babel-messages@>=6.3.13 <7.0.0",
+          "from": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.3.18.tgz",
           "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.3.18.tgz"
         },
         "babel-template": {
           "version": "6.3.13",
-          "from": "babel-template@>=6.3.13 <7.0.0",
+          "from": "https://registry.npmjs.org/babel-template/-/babel-template-6.3.13.tgz",
           "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.3.13.tgz"
         },
         "babel-runtime": {
           "version": "5.8.35",
-          "from": "babel-runtime@>=5.0.0 <6.0.0",
+          "from": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.35.tgz",
           "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.35.tgz",
           "dependencies": {
             "core-js": {
               "version": "1.2.6",
-              "from": "core-js@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz",
               "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
             }
           }
         },
         "babel-register": {
           "version": "6.4.3",
-          "from": "babel-register@>=6.3.13 <7.0.0",
+          "from": "https://registry.npmjs.org/babel-register/-/babel-register-6.4.3.tgz",
           "resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.4.3.tgz",
           "dependencies": {
             "core-js": {
               "version": "1.2.6",
-              "from": "core-js@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz",
               "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
             },
             "home-or-tmp": {
               "version": "1.0.0",
-              "from": "home-or-tmp@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-1.0.0.tgz",
               "dependencies": {
                 "os-tmpdir": {
                   "version": "1.0.1",
-                  "from": "os-tmpdir@>=1.0.1 <2.0.0",
+                  "from": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz"
                 },
                 "user-home": {
                   "version": "1.1.1",
-                  "from": "user-home@>=1.1.1 <2.0.0",
+                  "from": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
                   "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz"
                 }
               }
             },
             "mkdirp": {
               "version": "0.5.1",
-              "from": "mkdirp@>=0.5.1 <0.6.0",
+              "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
               "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
               "dependencies": {
                 "minimist": {
                   "version": "0.0.8",
-                  "from": "minimist@0.0.8",
+                  "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
                   "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
                 }
               }
             },
             "source-map-support": {
               "version": "0.2.10",
-              "from": "source-map-support@>=0.2.10 <0.3.0",
+              "from": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.2.10.tgz",
               "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.2.10.tgz",
               "dependencies": {
                 "source-map": {
                   "version": "0.1.32",
-                  "from": "source-map@0.1.32",
+                  "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.32.tgz",
                   "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.32.tgz",
                   "dependencies": {
                     "amdefine": {
                       "version": "1.0.0",
-                      "from": "amdefine@>=0.0.4",
+                      "from": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
                     }
                   }
@@ -262,27 +262,27 @@
         },
         "babel-traverse": {
           "version": "6.4.5",
-          "from": "babel-traverse@>=6.3.13 <7.0.0",
+          "from": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.4.5.tgz",
           "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.4.5.tgz",
           "dependencies": {
             "globals": {
               "version": "8.18.0",
-              "from": "globals@>=8.3.0 <9.0.0",
+              "from": "https://registry.npmjs.org/globals/-/globals-8.18.0.tgz",
               "resolved": "https://registry.npmjs.org/globals/-/globals-8.18.0.tgz"
             },
             "invariant": {
               "version": "2.2.0",
-              "from": "invariant@>=2.2.0 <3.0.0",
+              "from": "https://registry.npmjs.org/invariant/-/invariant-2.2.0.tgz",
               "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.0.tgz",
               "dependencies": {
                 "loose-envify": {
                   "version": "1.1.0",
-                  "from": "loose-envify@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz",
                   "dependencies": {
                     "js-tokens": {
                       "version": "1.0.2",
-                      "from": "js-tokens@>=1.0.1 <2.0.0",
+                      "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz",
                       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
                     }
                   }
@@ -291,17 +291,17 @@
             },
             "repeating": {
               "version": "1.1.3",
-              "from": "repeating@>=1.1.3 <2.0.0",
+              "from": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
               "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
               "dependencies": {
                 "is-finite": {
                   "version": "1.0.1",
-                  "from": "is-finite@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
                   "dependencies": {
                     "number-is-nan": {
                       "version": "1.0.0",
-                      "from": "number-is-nan@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
                     }
                   }
@@ -312,56 +312,56 @@
         },
         "babel-types": {
           "version": "6.4.5",
-          "from": "babel-types@>=6.4.0 <7.0.0",
+          "from": "https://registry.npmjs.org/babel-types/-/babel-types-6.4.5.tgz",
           "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.4.5.tgz",
           "dependencies": {
             "esutils": {
               "version": "2.0.2",
-              "from": "esutils@>=2.0.2 <3.0.0",
+              "from": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
               "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
             },
             "to-fast-properties": {
               "version": "1.0.1",
-              "from": "to-fast-properties@>=1.0.1 <2.0.0",
+              "from": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.1.tgz",
               "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.1.tgz"
             }
           }
         },
         "babylon": {
           "version": "6.4.5",
-          "from": "babylon@>=6.4.5 <7.0.0",
+          "from": "https://registry.npmjs.org/babylon/-/babylon-6.4.5.tgz",
           "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.4.5.tgz"
         },
         "convert-source-map": {
           "version": "1.1.3",
-          "from": "convert-source-map@>=1.1.0 <2.0.0",
+          "from": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.3.tgz",
           "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.3.tgz"
         },
         "debug": {
           "version": "2.2.0",
-          "from": "debug@>=2.1.1 <3.0.0",
+          "from": "debug@>=2.2.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
           "dependencies": {
             "ms": {
               "version": "0.7.1",
-              "from": "ms@0.7.1",
+              "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
               "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
             }
           }
         },
         "json5": {
           "version": "0.4.0",
-          "from": "json5@>=0.4.0 <0.5.0",
+          "from": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz",
           "resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz"
         },
         "minimatch": {
           "version": "2.0.10",
-          "from": "minimatch@>=2.0.3 <3.0.0",
+          "from": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
           "dependencies": {
             "brace-expansion": {
               "version": "1.1.2",
-              "from": "brace-expansion@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.2.tgz",
               "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.2.tgz",
               "dependencies": {
                 "balanced-match": {
@@ -380,107 +380,107 @@
         },
         "path-exists": {
           "version": "1.0.0",
-          "from": "path-exists@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/path-exists/-/path-exists-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-1.0.0.tgz"
         },
         "path-is-absolute": {
           "version": "1.0.0",
-          "from": "path-is-absolute@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
         },
         "private": {
           "version": "0.1.6",
-          "from": "private@>=0.1.6 <0.2.0",
+          "from": "https://registry.npmjs.org/private/-/private-0.1.6.tgz",
           "resolved": "https://registry.npmjs.org/private/-/private-0.1.6.tgz"
         },
         "shebang-regex": {
           "version": "1.0.0",
-          "from": "shebang-regex@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz"
         },
         "slash": {
           "version": "1.0.0",
-          "from": "slash@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz"
         },
         "source-map": {
           "version": "0.5.3",
-          "from": "source-map@>=0.5.0 <0.6.0",
+          "from": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz"
         }
       }
     },
     "babel-loader": {
       "version": "6.2.2",
-      "from": "babel-loader@>=6.0.1 <7.0.0",
+      "from": "https://registry.npmjs.org/babel-loader/-/babel-loader-6.2.2.tgz",
       "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-6.2.2.tgz",
       "dependencies": {
         "loader-utils": {
           "version": "0.2.12",
-          "from": "loader-utils@>=0.2.11 <0.3.0",
+          "from": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.12.tgz",
           "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.12.tgz",
           "dependencies": {
             "big.js": {
               "version": "3.1.3",
-              "from": "big.js@>=3.0.2 <4.0.0",
+              "from": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz",
               "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz"
             },
             "json5": {
               "version": "0.4.0",
-              "from": "json5@>=0.4.0 <0.5.0",
+              "from": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz",
               "resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz"
             }
           }
         },
         "mkdirp": {
           "version": "0.5.1",
-          "from": "mkdirp@>=0.5.1 <0.6.0",
+          "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "dependencies": {
             "minimist": {
               "version": "0.0.8",
-              "from": "minimist@0.0.8",
+              "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
               "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
             }
           }
         },
         "object-assign": {
           "version": "4.0.1",
-          "from": "object-assign@>=4.0.1 <5.0.0",
+          "from": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz",
           "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz"
         }
       }
     },
     "babel-plugin-jsx": {
       "version": "1.2.0",
-      "from": "babel-plugin-jsx@>=1.2.0 <2.0.0",
+      "from": "https://registry.npmjs.org/babel-plugin-jsx/-/babel-plugin-jsx-1.2.0.tgz",
       "resolved": "https://registry.npmjs.org/babel-plugin-jsx/-/babel-plugin-jsx-1.2.0.tgz",
       "dependencies": {
         "esutils": {
           "version": "2.0.2",
-          "from": "esutils@>=2.0.2 <3.0.0",
+          "from": "esutils@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
         }
       }
     },
     "babel-preset-es2015": {
       "version": "6.3.13",
-      "from": "babel-preset-es2015@>=6.1.2 <7.0.0",
+      "from": "https://registry.npmjs.org/babel-preset-es2015/-/babel-preset-es2015-6.3.13.tgz",
       "resolved": "https://registry.npmjs.org/babel-preset-es2015/-/babel-preset-es2015-6.3.13.tgz",
       "dependencies": {
         "babel-plugin-transform-es2015-template-literals": {
           "version": "6.3.13",
-          "from": "babel-plugin-transform-es2015-template-literals@>=6.3.13 <7.0.0",
+          "from": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.3.13.tgz",
           "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.3.13.tgz",
           "dependencies": {
             "babel-runtime": {
               "version": "5.8.35",
-              "from": "babel-runtime@>=5.0.0 <6.0.0",
+              "from": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.35.tgz",
               "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.35.tgz",
               "dependencies": {
                 "core-js": {
                   "version": "1.2.6",
-                  "from": "core-js@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz",
                   "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
                 }
               }
@@ -489,17 +489,17 @@
         },
         "babel-plugin-transform-es2015-literals": {
           "version": "6.3.13",
-          "from": "babel-plugin-transform-es2015-literals@>=6.3.13 <7.0.0",
+          "from": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.3.13.tgz",
           "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.3.13.tgz",
           "dependencies": {
             "babel-runtime": {
               "version": "5.8.35",
-              "from": "babel-runtime@>=5.0.0 <6.0.0",
+              "from": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.35.tgz",
               "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.35.tgz",
               "dependencies": {
                 "core-js": {
                   "version": "1.2.6",
-                  "from": "core-js@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz",
                   "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
                 }
               }
@@ -508,88 +508,88 @@
         },
         "babel-plugin-transform-es2015-function-name": {
           "version": "6.4.0",
-          "from": "babel-plugin-transform-es2015-function-name@>=6.3.13 <7.0.0",
+          "from": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.4.0.tgz",
           "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.4.0.tgz",
           "dependencies": {
             "babel-helper-function-name": {
               "version": "6.4.0",
-              "from": "babel-helper-function-name@>=6.4.0 <7.0.0",
+              "from": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.4.0.tgz",
               "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.4.0.tgz",
               "dependencies": {
                 "babel-traverse": {
                   "version": "6.4.5",
-                  "from": "babel-traverse@>=6.3.13 <7.0.0",
+                  "from": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.4.5.tgz",
                   "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.4.5.tgz",
                   "dependencies": {
                     "babel-code-frame": {
                       "version": "6.3.13",
-                      "from": "babel-code-frame@>=6.3.13 <7.0.0",
+                      "from": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.3.13.tgz",
                       "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.3.13.tgz",
                       "dependencies": {
                         "chalk": {
                           "version": "1.1.1",
-                          "from": "chalk@>=1.1.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
                           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
                           "dependencies": {
                             "ansi-styles": {
                               "version": "2.1.0",
-                              "from": "ansi-styles@>=2.1.0 <3.0.0",
+                              "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz",
                               "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
                             },
                             "escape-string-regexp": {
                               "version": "1.0.4",
-                              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                              "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz",
                               "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz"
                             },
                             "has-ansi": {
                               "version": "2.0.0",
-                              "from": "has-ansi@>=2.0.0 <3.0.0",
+                              "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                               "dependencies": {
                                 "ansi-regex": {
                                   "version": "2.0.0",
-                                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
                                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                                 }
                               }
                             },
                             "strip-ansi": {
                               "version": "3.0.0",
-                              "from": "strip-ansi@>=3.0.0 <4.0.0",
+                              "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
                               "dependencies": {
                                 "ansi-regex": {
                                   "version": "2.0.0",
-                                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
                                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                                 }
                               }
                             },
                             "supports-color": {
                               "version": "2.0.0",
-                              "from": "supports-color@>=2.0.0 <3.0.0",
+                              "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
                             }
                           }
                         },
                         "esutils": {
                           "version": "2.0.2",
-                          "from": "esutils@>=2.0.2 <3.0.0",
+                          "from": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
                           "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
                         },
                         "js-tokens": {
                           "version": "1.0.2",
-                          "from": "js-tokens@>=1.0.1 <2.0.0",
+                          "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz",
                           "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
                         },
                         "line-numbers": {
                           "version": "0.2.0",
-                          "from": "line-numbers@>=0.2.0 <0.3.0",
+                          "from": "https://registry.npmjs.org/line-numbers/-/line-numbers-0.2.0.tgz",
                           "resolved": "https://registry.npmjs.org/line-numbers/-/line-numbers-0.2.0.tgz",
                           "dependencies": {
                             "left-pad": {
                               "version": "0.0.3",
-                              "from": "left-pad@0.0.3",
+                              "from": "https://registry.npmjs.org/left-pad/-/left-pad-0.0.3.tgz",
                               "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-0.0.3.tgz"
                             }
                           }
@@ -598,44 +598,44 @@
                     },
                     "babel-messages": {
                       "version": "6.3.18",
-                      "from": "babel-messages@>=6.3.13 <7.0.0",
+                      "from": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.3.18.tgz",
                       "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.3.18.tgz"
                     },
                     "babylon": {
                       "version": "6.4.5",
-                      "from": "babylon@>=6.4.5 <7.0.0",
+                      "from": "https://registry.npmjs.org/babylon/-/babylon-6.4.5.tgz",
                       "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.4.5.tgz"
                     },
                     "debug": {
                       "version": "2.2.0",
-                      "from": "debug@>=2.2.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
                       "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
                       "dependencies": {
                         "ms": {
                           "version": "0.7.1",
-                          "from": "ms@0.7.1",
+                          "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
                           "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
                         }
                       }
                     },
                     "globals": {
                       "version": "8.18.0",
-                      "from": "globals@>=8.3.0 <9.0.0",
+                      "from": "https://registry.npmjs.org/globals/-/globals-8.18.0.tgz",
                       "resolved": "https://registry.npmjs.org/globals/-/globals-8.18.0.tgz"
                     },
                     "invariant": {
                       "version": "2.2.0",
-                      "from": "invariant@>=2.2.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/invariant/-/invariant-2.2.0.tgz",
                       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.0.tgz",
                       "dependencies": {
                         "loose-envify": {
                           "version": "1.1.0",
-                          "from": "loose-envify@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz",
                           "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz",
                           "dependencies": {
                             "js-tokens": {
                               "version": "1.0.2",
-                              "from": "js-tokens@>=1.0.1 <2.0.0",
+                              "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz",
                               "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
                             }
                           }
@@ -644,17 +644,17 @@
                     },
                     "repeating": {
                       "version": "1.1.3",
-                      "from": "repeating@>=1.1.3 <2.0.0",
+                      "from": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
                       "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
                       "dependencies": {
                         "is-finite": {
                           "version": "1.0.1",
-                          "from": "is-finite@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
                           "dependencies": {
                             "number-is-nan": {
                               "version": "1.0.0",
-                              "from": "number-is-nan@>=1.0.0 <2.0.0",
+                              "from": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
                             }
                           }
@@ -665,17 +665,17 @@
                 },
                 "babel-helper-get-function-arity": {
                   "version": "6.3.13",
-                  "from": "babel-helper-get-function-arity@>=6.3.13 <7.0.0",
+                  "from": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.3.13.tgz",
                   "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.3.13.tgz"
                 },
                 "babel-template": {
                   "version": "6.3.13",
-                  "from": "babel-template@>=6.3.13 <7.0.0",
+                  "from": "https://registry.npmjs.org/babel-template/-/babel-template-6.3.13.tgz",
                   "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.3.13.tgz",
                   "dependencies": {
                     "babylon": {
                       "version": "6.4.5",
-                      "from": "babylon@>=6.3.13 <7.0.0",
+                      "from": "https://registry.npmjs.org/babylon/-/babylon-6.4.5.tgz",
                       "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.4.5.tgz"
                     }
                   }
@@ -684,78 +684,78 @@
             },
             "babel-types": {
               "version": "6.4.5",
-              "from": "babel-types@>=6.4.0 <7.0.0",
+              "from": "https://registry.npmjs.org/babel-types/-/babel-types-6.4.5.tgz",
               "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.4.5.tgz",
               "dependencies": {
                 "babel-traverse": {
                   "version": "6.4.5",
-                  "from": "babel-traverse@>=6.4.5 <7.0.0",
+                  "from": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.4.5.tgz",
                   "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.4.5.tgz",
                   "dependencies": {
                     "babel-code-frame": {
                       "version": "6.3.13",
-                      "from": "babel-code-frame@>=6.3.13 <7.0.0",
+                      "from": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.3.13.tgz",
                       "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.3.13.tgz",
                       "dependencies": {
                         "chalk": {
                           "version": "1.1.1",
-                          "from": "chalk@>=1.1.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
                           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
                           "dependencies": {
                             "ansi-styles": {
                               "version": "2.1.0",
-                              "from": "ansi-styles@>=2.1.0 <3.0.0",
+                              "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz",
                               "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
                             },
                             "escape-string-regexp": {
                               "version": "1.0.4",
-                              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                              "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz",
                               "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz"
                             },
                             "has-ansi": {
                               "version": "2.0.0",
-                              "from": "has-ansi@>=2.0.0 <3.0.0",
+                              "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                               "dependencies": {
                                 "ansi-regex": {
                                   "version": "2.0.0",
-                                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
                                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                                 }
                               }
                             },
                             "strip-ansi": {
                               "version": "3.0.0",
-                              "from": "strip-ansi@>=3.0.0 <4.0.0",
+                              "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
                               "dependencies": {
                                 "ansi-regex": {
                                   "version": "2.0.0",
-                                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
                                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                                 }
                               }
                             },
                             "supports-color": {
                               "version": "2.0.0",
-                              "from": "supports-color@>=2.0.0 <3.0.0",
+                              "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
                             }
                           }
                         },
                         "js-tokens": {
                           "version": "1.0.2",
-                          "from": "js-tokens@>=1.0.1 <2.0.0",
+                          "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz",
                           "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
                         },
                         "line-numbers": {
                           "version": "0.2.0",
-                          "from": "line-numbers@>=0.2.0 <0.3.0",
+                          "from": "https://registry.npmjs.org/line-numbers/-/line-numbers-0.2.0.tgz",
                           "resolved": "https://registry.npmjs.org/line-numbers/-/line-numbers-0.2.0.tgz",
                           "dependencies": {
                             "left-pad": {
                               "version": "0.0.3",
-                              "from": "left-pad@0.0.3",
+                              "from": "https://registry.npmjs.org/left-pad/-/left-pad-0.0.3.tgz",
                               "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-0.0.3.tgz"
                             }
                           }
@@ -764,44 +764,44 @@
                     },
                     "babel-messages": {
                       "version": "6.3.18",
-                      "from": "babel-messages@>=6.3.13 <7.0.0",
+                      "from": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.3.18.tgz",
                       "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.3.18.tgz"
                     },
                     "babylon": {
                       "version": "6.4.5",
-                      "from": "babylon@>=6.4.5 <7.0.0",
+                      "from": "https://registry.npmjs.org/babylon/-/babylon-6.4.5.tgz",
                       "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.4.5.tgz"
                     },
                     "debug": {
                       "version": "2.2.0",
-                      "from": "debug@>=2.2.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
                       "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
                       "dependencies": {
                         "ms": {
                           "version": "0.7.1",
-                          "from": "ms@0.7.1",
+                          "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
                           "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
                         }
                       }
                     },
                     "globals": {
                       "version": "8.18.0",
-                      "from": "globals@>=8.3.0 <9.0.0",
+                      "from": "https://registry.npmjs.org/globals/-/globals-8.18.0.tgz",
                       "resolved": "https://registry.npmjs.org/globals/-/globals-8.18.0.tgz"
                     },
                     "invariant": {
                       "version": "2.2.0",
-                      "from": "invariant@>=2.2.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/invariant/-/invariant-2.2.0.tgz",
                       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.0.tgz",
                       "dependencies": {
                         "loose-envify": {
                           "version": "1.1.0",
-                          "from": "loose-envify@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz",
                           "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz",
                           "dependencies": {
                             "js-tokens": {
                               "version": "1.0.2",
-                              "from": "js-tokens@>=1.0.1 <2.0.0",
+                              "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz",
                               "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
                             }
                           }
@@ -810,17 +810,17 @@
                     },
                     "repeating": {
                       "version": "1.1.3",
-                      "from": "repeating@>=1.1.3 <2.0.0",
+                      "from": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
                       "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
                       "dependencies": {
                         "is-finite": {
                           "version": "1.0.1",
-                          "from": "is-finite@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
                           "dependencies": {
                             "number-is-nan": {
                               "version": "1.0.0",
-                              "from": "number-is-nan@>=1.0.0 <2.0.0",
+                              "from": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
                             }
                           }
@@ -831,24 +831,24 @@
                 },
                 "esutils": {
                   "version": "2.0.2",
-                  "from": "esutils@>=2.0.2 <3.0.0",
+                  "from": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
                 },
                 "to-fast-properties": {
                   "version": "1.0.1",
-                  "from": "to-fast-properties@>=1.0.1 <2.0.0",
+                  "from": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.1.tgz"
                 }
               }
             },
             "babel-runtime": {
               "version": "5.8.35",
-              "from": "babel-runtime@>=5.0.0 <6.0.0",
+              "from": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.35.tgz",
               "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.35.tgz",
               "dependencies": {
                 "core-js": {
                   "version": "1.2.6",
-                  "from": "core-js@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz",
                   "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
                 }
               }
@@ -857,17 +857,17 @@
         },
         "babel-plugin-transform-es2015-arrow-functions": {
           "version": "6.4.0",
-          "from": "babel-plugin-transform-es2015-arrow-functions@>=6.3.13 <7.0.0",
+          "from": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.4.0.tgz",
           "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.4.0.tgz",
           "dependencies": {
             "babel-runtime": {
               "version": "5.8.35",
-              "from": "babel-runtime@>=5.0.0 <6.0.0",
+              "from": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.35.tgz",
               "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.35.tgz",
               "dependencies": {
                 "core-js": {
                   "version": "1.2.6",
-                  "from": "core-js@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz",
                   "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
                 }
               }
@@ -876,17 +876,17 @@
         },
         "babel-plugin-transform-es2015-block-scoped-functions": {
           "version": "6.3.13",
-          "from": "babel-plugin-transform-es2015-block-scoped-functions@>=6.3.13 <7.0.0",
+          "from": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.3.13.tgz",
           "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.3.13.tgz",
           "dependencies": {
             "babel-runtime": {
               "version": "5.8.35",
-              "from": "babel-runtime@>=5.0.0 <6.0.0",
+              "from": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.35.tgz",
               "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.35.tgz",
               "dependencies": {
                 "core-js": {
                   "version": "1.2.6",
-                  "from": "core-js@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz",
                   "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
                 }
               }
@@ -895,117 +895,117 @@
         },
         "babel-plugin-transform-es2015-classes": {
           "version": "6.4.5",
-          "from": "babel-plugin-transform-es2015-classes@>=6.3.13 <7.0.0",
+          "from": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.4.5.tgz",
           "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.4.5.tgz",
           "dependencies": {
             "babel-helper-optimise-call-expression": {
               "version": "6.3.13",
-              "from": "babel-helper-optimise-call-expression@>=6.3.13 <7.0.0",
+              "from": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.3.13.tgz",
               "resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.3.13.tgz"
             },
             "babel-helper-function-name": {
               "version": "6.4.0",
-              "from": "babel-helper-function-name@>=6.4.0 <7.0.0",
+              "from": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.4.0.tgz",
               "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.4.0.tgz",
               "dependencies": {
                 "babel-helper-get-function-arity": {
                   "version": "6.3.13",
-                  "from": "babel-helper-get-function-arity@>=6.3.13 <7.0.0",
+                  "from": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.3.13.tgz",
                   "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.3.13.tgz"
                 }
               }
             },
             "babel-helper-replace-supers": {
               "version": "6.3.13",
-              "from": "babel-helper-replace-supers@>=6.3.13 <7.0.0",
+              "from": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.3.13.tgz",
               "resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.3.13.tgz"
             },
             "babel-template": {
               "version": "6.3.13",
-              "from": "babel-template@>=6.3.13 <7.0.0",
+              "from": "https://registry.npmjs.org/babel-template/-/babel-template-6.3.13.tgz",
               "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.3.13.tgz",
               "dependencies": {
                 "babylon": {
                   "version": "6.4.5",
-                  "from": "babylon@>=6.3.13 <7.0.0",
+                  "from": "https://registry.npmjs.org/babylon/-/babylon-6.4.5.tgz",
                   "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.4.5.tgz"
                 }
               }
             },
             "babel-traverse": {
               "version": "6.4.5",
-              "from": "babel-traverse@>=6.4.5 <7.0.0",
+              "from": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.4.5.tgz",
               "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.4.5.tgz",
               "dependencies": {
                 "babel-code-frame": {
                   "version": "6.3.13",
-                  "from": "babel-code-frame@>=6.3.13 <7.0.0",
+                  "from": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.3.13.tgz",
                   "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.3.13.tgz",
                   "dependencies": {
                     "chalk": {
                       "version": "1.1.1",
-                      "from": "chalk@>=1.1.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
                       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
                       "dependencies": {
                         "ansi-styles": {
                           "version": "2.1.0",
-                          "from": "ansi-styles@>=2.1.0 <3.0.0",
+                          "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz",
                           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
                         },
                         "escape-string-regexp": {
                           "version": "1.0.4",
-                          "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                          "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz",
                           "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz"
                         },
                         "has-ansi": {
                           "version": "2.0.0",
-                          "from": "has-ansi@>=2.0.0 <3.0.0",
+                          "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                           "dependencies": {
                             "ansi-regex": {
                               "version": "2.0.0",
-                              "from": "ansi-regex@>=2.0.0 <3.0.0",
+                              "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                             }
                           }
                         },
                         "strip-ansi": {
                           "version": "3.0.0",
-                          "from": "strip-ansi@>=3.0.0 <4.0.0",
+                          "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
                           "dependencies": {
                             "ansi-regex": {
                               "version": "2.0.0",
-                              "from": "ansi-regex@>=2.0.0 <3.0.0",
+                              "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                             }
                           }
                         },
                         "supports-color": {
                           "version": "2.0.0",
-                          "from": "supports-color@>=2.0.0 <3.0.0",
+                          "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
                         }
                       }
                     },
                     "esutils": {
                       "version": "2.0.2",
-                      "from": "esutils@>=2.0.2 <3.0.0",
+                      "from": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
                       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
                     },
                     "js-tokens": {
                       "version": "1.0.2",
-                      "from": "js-tokens@>=1.0.1 <2.0.0",
+                      "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz",
                       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
                     },
                     "line-numbers": {
                       "version": "0.2.0",
-                      "from": "line-numbers@>=0.2.0 <0.3.0",
+                      "from": "https://registry.npmjs.org/line-numbers/-/line-numbers-0.2.0.tgz",
                       "resolved": "https://registry.npmjs.org/line-numbers/-/line-numbers-0.2.0.tgz",
                       "dependencies": {
                         "left-pad": {
                           "version": "0.0.3",
-                          "from": "left-pad@0.0.3",
+                          "from": "https://registry.npmjs.org/left-pad/-/left-pad-0.0.3.tgz",
                           "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-0.0.3.tgz"
                         }
                       }
@@ -1014,39 +1014,39 @@
                 },
                 "babylon": {
                   "version": "6.4.5",
-                  "from": "babylon@>=6.4.5 <7.0.0",
+                  "from": "https://registry.npmjs.org/babylon/-/babylon-6.4.5.tgz",
                   "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.4.5.tgz"
                 },
                 "debug": {
                   "version": "2.2.0",
-                  "from": "debug@>=2.2.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
                   "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
                   "dependencies": {
                     "ms": {
                       "version": "0.7.1",
-                      "from": "ms@0.7.1",
+                      "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
                       "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
                     }
                   }
                 },
                 "globals": {
                   "version": "8.18.0",
-                  "from": "globals@>=8.3.0 <9.0.0",
+                  "from": "https://registry.npmjs.org/globals/-/globals-8.18.0.tgz",
                   "resolved": "https://registry.npmjs.org/globals/-/globals-8.18.0.tgz"
                 },
                 "invariant": {
                   "version": "2.2.0",
-                  "from": "invariant@>=2.2.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/invariant/-/invariant-2.2.0.tgz",
                   "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.0.tgz",
                   "dependencies": {
                     "loose-envify": {
                       "version": "1.1.0",
-                      "from": "loose-envify@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz",
                       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz",
                       "dependencies": {
                         "js-tokens": {
                           "version": "1.0.2",
-                          "from": "js-tokens@>=1.0.1 <2.0.0",
+                          "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz",
                           "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
                         }
                       }
@@ -1055,17 +1055,17 @@
                 },
                 "repeating": {
                   "version": "1.1.3",
-                  "from": "repeating@>=1.1.3 <2.0.0",
+                  "from": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
                   "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
                   "dependencies": {
                     "is-finite": {
                       "version": "1.0.1",
-                      "from": "is-finite@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
                       "dependencies": {
                         "number-is-nan": {
                           "version": "1.0.0",
-                          "from": "number-is-nan@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
                         }
                       }
@@ -1076,39 +1076,39 @@
             },
             "babel-helper-define-map": {
               "version": "6.4.5",
-              "from": "babel-helper-define-map@>=6.4.5 <7.0.0",
+              "from": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.4.5.tgz",
               "resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.4.5.tgz"
             },
             "babel-messages": {
               "version": "6.3.18",
-              "from": "babel-messages@>=6.3.13 <7.0.0",
+              "from": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.3.18.tgz",
               "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.3.18.tgz"
             },
             "babel-runtime": {
               "version": "5.8.35",
-              "from": "babel-runtime@>=5.0.0 <6.0.0",
+              "from": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.35.tgz",
               "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.35.tgz",
               "dependencies": {
                 "core-js": {
                   "version": "1.2.6",
-                  "from": "core-js@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz",
                   "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
                 }
               }
             },
             "babel-types": {
               "version": "6.4.5",
-              "from": "babel-types@>=6.4.5 <7.0.0",
+              "from": "https://registry.npmjs.org/babel-types/-/babel-types-6.4.5.tgz",
               "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.4.5.tgz",
               "dependencies": {
                 "esutils": {
                   "version": "2.0.2",
-                  "from": "esutils@>=2.0.2 <3.0.0",
+                  "from": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
                 },
                 "to-fast-properties": {
                   "version": "1.0.1",
-                  "from": "to-fast-properties@>=1.0.1 <2.0.0",
+                  "from": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.1.tgz"
                 }
               }
@@ -1117,93 +1117,93 @@
         },
         "babel-plugin-transform-es2015-object-super": {
           "version": "6.4.0",
-          "from": "babel-plugin-transform-es2015-object-super@>=6.3.13 <7.0.0",
+          "from": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.4.0.tgz",
           "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.4.0.tgz",
           "dependencies": {
             "babel-helper-replace-supers": {
               "version": "6.3.13",
-              "from": "babel-helper-replace-supers@>=6.3.13 <7.0.0",
+              "from": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.3.13.tgz",
               "resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.3.13.tgz",
               "dependencies": {
                 "babel-helper-optimise-call-expression": {
                   "version": "6.3.13",
-                  "from": "babel-helper-optimise-call-expression@>=6.3.13 <7.0.0",
+                  "from": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.3.13.tgz",
                   "resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.3.13.tgz"
                 },
                 "babel-traverse": {
                   "version": "6.4.5",
-                  "from": "babel-traverse@>=6.3.13 <7.0.0",
+                  "from": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.4.5.tgz",
                   "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.4.5.tgz",
                   "dependencies": {
                     "babel-code-frame": {
                       "version": "6.3.13",
-                      "from": "babel-code-frame@>=6.3.13 <7.0.0",
+                      "from": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.3.13.tgz",
                       "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.3.13.tgz",
                       "dependencies": {
                         "chalk": {
                           "version": "1.1.1",
-                          "from": "chalk@>=1.1.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
                           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
                           "dependencies": {
                             "ansi-styles": {
                               "version": "2.1.0",
-                              "from": "ansi-styles@>=2.1.0 <3.0.0",
+                              "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz",
                               "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
                             },
                             "escape-string-regexp": {
                               "version": "1.0.4",
-                              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                              "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz",
                               "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz"
                             },
                             "has-ansi": {
                               "version": "2.0.0",
-                              "from": "has-ansi@>=2.0.0 <3.0.0",
+                              "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                               "dependencies": {
                                 "ansi-regex": {
                                   "version": "2.0.0",
-                                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
                                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                                 }
                               }
                             },
                             "strip-ansi": {
                               "version": "3.0.0",
-                              "from": "strip-ansi@>=3.0.0 <4.0.0",
+                              "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
                               "dependencies": {
                                 "ansi-regex": {
                                   "version": "2.0.0",
-                                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
                                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                                 }
                               }
                             },
                             "supports-color": {
                               "version": "2.0.0",
-                              "from": "supports-color@>=2.0.0 <3.0.0",
+                              "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
                             }
                           }
                         },
                         "esutils": {
                           "version": "2.0.2",
-                          "from": "esutils@>=2.0.2 <3.0.0",
+                          "from": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
                           "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
                         },
                         "js-tokens": {
                           "version": "1.0.2",
-                          "from": "js-tokens@>=1.0.1 <2.0.0",
+                          "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz",
                           "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
                         },
                         "line-numbers": {
                           "version": "0.2.0",
-                          "from": "line-numbers@>=0.2.0 <0.3.0",
+                          "from": "https://registry.npmjs.org/line-numbers/-/line-numbers-0.2.0.tgz",
                           "resolved": "https://registry.npmjs.org/line-numbers/-/line-numbers-0.2.0.tgz",
                           "dependencies": {
                             "left-pad": {
                               "version": "0.0.3",
-                              "from": "left-pad@0.0.3",
+                              "from": "https://registry.npmjs.org/left-pad/-/left-pad-0.0.3.tgz",
                               "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-0.0.3.tgz"
                             }
                           }
@@ -1212,39 +1212,39 @@
                     },
                     "babylon": {
                       "version": "6.4.5",
-                      "from": "babylon@>=6.4.5 <7.0.0",
+                      "from": "https://registry.npmjs.org/babylon/-/babylon-6.4.5.tgz",
                       "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.4.5.tgz"
                     },
                     "debug": {
                       "version": "2.2.0",
-                      "from": "debug@>=2.2.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
                       "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
                       "dependencies": {
                         "ms": {
                           "version": "0.7.1",
-                          "from": "ms@0.7.1",
+                          "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
                           "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
                         }
                       }
                     },
                     "globals": {
                       "version": "8.18.0",
-                      "from": "globals@>=8.3.0 <9.0.0",
+                      "from": "https://registry.npmjs.org/globals/-/globals-8.18.0.tgz",
                       "resolved": "https://registry.npmjs.org/globals/-/globals-8.18.0.tgz"
                     },
                     "invariant": {
                       "version": "2.2.0",
-                      "from": "invariant@>=2.2.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/invariant/-/invariant-2.2.0.tgz",
                       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.0.tgz",
                       "dependencies": {
                         "loose-envify": {
                           "version": "1.1.0",
-                          "from": "loose-envify@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz",
                           "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz",
                           "dependencies": {
                             "js-tokens": {
                               "version": "1.0.2",
-                              "from": "js-tokens@>=1.0.1 <2.0.0",
+                              "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz",
                               "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
                             }
                           }
@@ -1253,17 +1253,17 @@
                     },
                     "repeating": {
                       "version": "1.1.3",
-                      "from": "repeating@>=1.1.3 <2.0.0",
+                      "from": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
                       "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
                       "dependencies": {
                         "is-finite": {
                           "version": "1.0.1",
-                          "from": "is-finite@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
                           "dependencies": {
                             "number-is-nan": {
                               "version": "1.0.0",
-                              "from": "number-is-nan@>=1.0.0 <2.0.0",
+                              "from": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
                             }
                           }
@@ -1274,34 +1274,34 @@
                 },
                 "babel-messages": {
                   "version": "6.3.18",
-                  "from": "babel-messages@>=6.3.13 <7.0.0",
+                  "from": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.3.18.tgz",
                   "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.3.18.tgz"
                 },
                 "babel-template": {
                   "version": "6.3.13",
-                  "from": "babel-template@>=6.3.13 <7.0.0",
+                  "from": "https://registry.npmjs.org/babel-template/-/babel-template-6.3.13.tgz",
                   "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.3.13.tgz",
                   "dependencies": {
                     "babylon": {
                       "version": "6.4.5",
-                      "from": "babylon@>=6.3.13 <7.0.0",
+                      "from": "https://registry.npmjs.org/babylon/-/babylon-6.4.5.tgz",
                       "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.4.5.tgz"
                     }
                   }
                 },
                 "babel-types": {
                   "version": "6.4.5",
-                  "from": "babel-types@>=6.3.13 <7.0.0",
+                  "from": "https://registry.npmjs.org/babel-types/-/babel-types-6.4.5.tgz",
                   "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.4.5.tgz",
                   "dependencies": {
                     "esutils": {
                       "version": "2.0.2",
-                      "from": "esutils@>=2.0.2 <3.0.0",
+                      "from": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
                       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
                     },
                     "to-fast-properties": {
                       "version": "1.0.1",
-                      "from": "to-fast-properties@>=1.0.1 <2.0.0",
+                      "from": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.1.tgz"
                     }
                   }
@@ -1310,12 +1310,12 @@
             },
             "babel-runtime": {
               "version": "5.8.35",
-              "from": "babel-runtime@>=5.0.0 <6.0.0",
+              "from": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.35.tgz",
               "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.35.tgz",
               "dependencies": {
                 "core-js": {
                   "version": "1.2.6",
-                  "from": "core-js@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz",
                   "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
                 }
               }
@@ -1324,83 +1324,83 @@
         },
         "babel-plugin-transform-es2015-shorthand-properties": {
           "version": "6.3.13",
-          "from": "babel-plugin-transform-es2015-shorthand-properties@>=6.3.13 <7.0.0",
+          "from": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.3.13.tgz",
           "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.3.13.tgz",
           "dependencies": {
             "babel-types": {
               "version": "6.4.5",
-              "from": "babel-types@>=6.4.0 <7.0.0",
+              "from": "https://registry.npmjs.org/babel-types/-/babel-types-6.4.5.tgz",
               "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.4.5.tgz",
               "dependencies": {
                 "babel-traverse": {
                   "version": "6.4.5",
-                  "from": "babel-traverse@>=6.4.5 <7.0.0",
+                  "from": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.4.5.tgz",
                   "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.4.5.tgz",
                   "dependencies": {
                     "babel-code-frame": {
                       "version": "6.3.13",
-                      "from": "babel-code-frame@>=6.3.13 <7.0.0",
+                      "from": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.3.13.tgz",
                       "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.3.13.tgz",
                       "dependencies": {
                         "chalk": {
                           "version": "1.1.1",
-                          "from": "chalk@>=1.1.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
                           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
                           "dependencies": {
                             "ansi-styles": {
                               "version": "2.1.0",
-                              "from": "ansi-styles@>=2.1.0 <3.0.0",
+                              "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz",
                               "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
                             },
                             "escape-string-regexp": {
                               "version": "1.0.4",
-                              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                              "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz",
                               "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz"
                             },
                             "has-ansi": {
                               "version": "2.0.0",
-                              "from": "has-ansi@>=2.0.0 <3.0.0",
+                              "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                               "dependencies": {
                                 "ansi-regex": {
                                   "version": "2.0.0",
-                                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
                                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                                 }
                               }
                             },
                             "strip-ansi": {
                               "version": "3.0.0",
-                              "from": "strip-ansi@>=3.0.0 <4.0.0",
+                              "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
                               "dependencies": {
                                 "ansi-regex": {
                                   "version": "2.0.0",
-                                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
                                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                                 }
                               }
                             },
                             "supports-color": {
                               "version": "2.0.0",
-                              "from": "supports-color@>=2.0.0 <3.0.0",
+                              "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
                             }
                           }
                         },
                         "js-tokens": {
                           "version": "1.0.2",
-                          "from": "js-tokens@>=1.0.1 <2.0.0",
+                          "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz",
                           "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
                         },
                         "line-numbers": {
                           "version": "0.2.0",
-                          "from": "line-numbers@>=0.2.0 <0.3.0",
+                          "from": "https://registry.npmjs.org/line-numbers/-/line-numbers-0.2.0.tgz",
                           "resolved": "https://registry.npmjs.org/line-numbers/-/line-numbers-0.2.0.tgz",
                           "dependencies": {
                             "left-pad": {
                               "version": "0.0.3",
-                              "from": "left-pad@0.0.3",
+                              "from": "https://registry.npmjs.org/left-pad/-/left-pad-0.0.3.tgz",
                               "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-0.0.3.tgz"
                             }
                           }
@@ -1409,44 +1409,44 @@
                     },
                     "babel-messages": {
                       "version": "6.3.18",
-                      "from": "babel-messages@>=6.3.13 <7.0.0",
+                      "from": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.3.18.tgz",
                       "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.3.18.tgz"
                     },
                     "babylon": {
                       "version": "6.4.5",
-                      "from": "babylon@>=6.4.5 <7.0.0",
+                      "from": "https://registry.npmjs.org/babylon/-/babylon-6.4.5.tgz",
                       "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.4.5.tgz"
                     },
                     "debug": {
                       "version": "2.2.0",
-                      "from": "debug@>=2.2.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
                       "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
                       "dependencies": {
                         "ms": {
                           "version": "0.7.1",
-                          "from": "ms@0.7.1",
+                          "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
                           "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
                         }
                       }
                     },
                     "globals": {
                       "version": "8.18.0",
-                      "from": "globals@>=8.3.0 <9.0.0",
+                      "from": "https://registry.npmjs.org/globals/-/globals-8.18.0.tgz",
                       "resolved": "https://registry.npmjs.org/globals/-/globals-8.18.0.tgz"
                     },
                     "invariant": {
                       "version": "2.2.0",
-                      "from": "invariant@>=2.2.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/invariant/-/invariant-2.2.0.tgz",
                       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.0.tgz",
                       "dependencies": {
                         "loose-envify": {
                           "version": "1.1.0",
-                          "from": "loose-envify@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz",
                           "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz",
                           "dependencies": {
                             "js-tokens": {
                               "version": "1.0.2",
-                              "from": "js-tokens@>=1.0.1 <2.0.0",
+                              "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz",
                               "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
                             }
                           }
@@ -1455,17 +1455,17 @@
                     },
                     "repeating": {
                       "version": "1.1.3",
-                      "from": "repeating@>=1.1.3 <2.0.0",
+                      "from": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
                       "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
                       "dependencies": {
                         "is-finite": {
                           "version": "1.0.1",
-                          "from": "is-finite@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
                           "dependencies": {
                             "number-is-nan": {
                               "version": "1.0.0",
-                              "from": "number-is-nan@>=1.0.0 <2.0.0",
+                              "from": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
                             }
                           }
@@ -1476,24 +1476,24 @@
                 },
                 "esutils": {
                   "version": "2.0.2",
-                  "from": "esutils@>=2.0.2 <3.0.0",
+                  "from": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
                 },
                 "to-fast-properties": {
                   "version": "1.0.1",
-                  "from": "to-fast-properties@>=1.0.1 <2.0.0",
+                  "from": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.1.tgz"
                 }
               }
             },
             "babel-runtime": {
               "version": "5.8.35",
-              "from": "babel-runtime@>=5.0.0 <6.0.0",
+              "from": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.35.tgz",
               "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.35.tgz",
               "dependencies": {
                 "core-js": {
                   "version": "1.2.6",
-                  "from": "core-js@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz",
                   "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
                 }
               }
@@ -1502,88 +1502,88 @@
         },
         "babel-plugin-transform-es2015-computed-properties": {
           "version": "6.4.0",
-          "from": "babel-plugin-transform-es2015-computed-properties@>=6.3.13 <7.0.0",
+          "from": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.4.0.tgz",
           "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.4.0.tgz",
           "dependencies": {
             "babel-helper-define-map": {
               "version": "6.4.5",
-              "from": "babel-helper-define-map@>=6.4.5 <7.0.0",
+              "from": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.4.5.tgz",
               "resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.4.5.tgz",
               "dependencies": {
                 "babel-types": {
                   "version": "6.4.5",
-                  "from": "babel-types@>=6.4.3 <7.0.0",
+                  "from": "https://registry.npmjs.org/babel-types/-/babel-types-6.4.5.tgz",
                   "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.4.5.tgz",
                   "dependencies": {
                     "babel-traverse": {
                       "version": "6.4.5",
-                      "from": "babel-traverse@>=6.4.5 <7.0.0",
+                      "from": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.4.5.tgz",
                       "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.4.5.tgz",
                       "dependencies": {
                         "babel-code-frame": {
                           "version": "6.3.13",
-                          "from": "babel-code-frame@>=6.3.13 <7.0.0",
+                          "from": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.3.13.tgz",
                           "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.3.13.tgz",
                           "dependencies": {
                             "chalk": {
                               "version": "1.1.1",
-                              "from": "chalk@>=1.1.0 <2.0.0",
+                              "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
                               "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
                               "dependencies": {
                                 "ansi-styles": {
                                   "version": "2.1.0",
-                                  "from": "ansi-styles@>=2.1.0 <3.0.0",
+                                  "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz",
                                   "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
                                 },
                                 "escape-string-regexp": {
                                   "version": "1.0.4",
-                                  "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                                  "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz",
                                   "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz"
                                 },
                                 "has-ansi": {
                                   "version": "2.0.0",
-                                  "from": "has-ansi@>=2.0.0 <3.0.0",
+                                  "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                                   "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                                   "dependencies": {
                                     "ansi-regex": {
                                       "version": "2.0.0",
-                                      "from": "ansi-regex@>=2.0.0 <3.0.0",
+                                      "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
                                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                                     }
                                   }
                                 },
                                 "strip-ansi": {
                                   "version": "3.0.0",
-                                  "from": "strip-ansi@>=3.0.0 <4.0.0",
+                                  "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
                                   "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
                                   "dependencies": {
                                     "ansi-regex": {
                                       "version": "2.0.0",
-                                      "from": "ansi-regex@>=2.0.0 <3.0.0",
+                                      "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
                                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                                     }
                                   }
                                 },
                                 "supports-color": {
                                   "version": "2.0.0",
-                                  "from": "supports-color@>=2.0.0 <3.0.0",
+                                  "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
                                   "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
                                 }
                               }
                             },
                             "js-tokens": {
                               "version": "1.0.2",
-                              "from": "js-tokens@>=1.0.1 <2.0.0",
+                              "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz",
                               "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
                             },
                             "line-numbers": {
                               "version": "0.2.0",
-                              "from": "line-numbers@>=0.2.0 <0.3.0",
+                              "from": "https://registry.npmjs.org/line-numbers/-/line-numbers-0.2.0.tgz",
                               "resolved": "https://registry.npmjs.org/line-numbers/-/line-numbers-0.2.0.tgz",
                               "dependencies": {
                                 "left-pad": {
                                   "version": "0.0.3",
-                                  "from": "left-pad@0.0.3",
+                                  "from": "https://registry.npmjs.org/left-pad/-/left-pad-0.0.3.tgz",
                                   "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-0.0.3.tgz"
                                 }
                               }
@@ -1592,44 +1592,44 @@
                         },
                         "babel-messages": {
                           "version": "6.3.18",
-                          "from": "babel-messages@>=6.3.13 <7.0.0",
+                          "from": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.3.18.tgz",
                           "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.3.18.tgz"
                         },
                         "babylon": {
                           "version": "6.4.5",
-                          "from": "babylon@>=6.4.5 <7.0.0",
+                          "from": "https://registry.npmjs.org/babylon/-/babylon-6.4.5.tgz",
                           "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.4.5.tgz"
                         },
                         "debug": {
                           "version": "2.2.0",
-                          "from": "debug@>=2.2.0 <3.0.0",
+                          "from": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
                           "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
                           "dependencies": {
                             "ms": {
                               "version": "0.7.1",
-                              "from": "ms@0.7.1",
+                              "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
                               "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
                             }
                           }
                         },
                         "globals": {
                           "version": "8.18.0",
-                          "from": "globals@>=8.3.0 <9.0.0",
+                          "from": "https://registry.npmjs.org/globals/-/globals-8.18.0.tgz",
                           "resolved": "https://registry.npmjs.org/globals/-/globals-8.18.0.tgz"
                         },
                         "invariant": {
                           "version": "2.2.0",
-                          "from": "invariant@>=2.2.0 <3.0.0",
+                          "from": "https://registry.npmjs.org/invariant/-/invariant-2.2.0.tgz",
                           "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.0.tgz",
                           "dependencies": {
                             "loose-envify": {
                               "version": "1.1.0",
-                              "from": "loose-envify@>=1.0.0 <2.0.0",
+                              "from": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz",
                               "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz",
                               "dependencies": {
                                 "js-tokens": {
                                   "version": "1.0.2",
-                                  "from": "js-tokens@>=1.0.1 <2.0.0",
+                                  "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz",
                                   "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
                                 }
                               }
@@ -1638,17 +1638,17 @@
                         },
                         "repeating": {
                           "version": "1.1.3",
-                          "from": "repeating@>=1.1.3 <2.0.0",
+                          "from": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
                           "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
                           "dependencies": {
                             "is-finite": {
                               "version": "1.0.1",
-                              "from": "is-finite@>=1.0.0 <2.0.0",
+                              "from": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
                               "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
                               "dependencies": {
                                 "number-is-nan": {
                                   "version": "1.0.0",
-                                  "from": "number-is-nan@>=1.0.0 <2.0.0",
+                                  "from": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
                                   "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
                                 }
                               }
@@ -1659,95 +1659,95 @@
                     },
                     "esutils": {
                       "version": "2.0.2",
-                      "from": "esutils@>=2.0.2 <3.0.0",
+                      "from": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
                       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
                     },
                     "to-fast-properties": {
                       "version": "1.0.1",
-                      "from": "to-fast-properties@>=1.0.1 <2.0.0",
+                      "from": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.1.tgz"
                     }
                   }
                 },
                 "babel-helper-function-name": {
                   "version": "6.4.0",
-                  "from": "babel-helper-function-name@>=6.3.13 <7.0.0",
+                  "from": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.4.0.tgz",
                   "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.4.0.tgz",
                   "dependencies": {
                     "babel-traverse": {
                       "version": "6.4.5",
-                      "from": "babel-traverse@>=6.3.15 <7.0.0",
+                      "from": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.4.5.tgz",
                       "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.4.5.tgz",
                       "dependencies": {
                         "babel-code-frame": {
                           "version": "6.3.13",
-                          "from": "babel-code-frame@>=6.3.13 <7.0.0",
+                          "from": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.3.13.tgz",
                           "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.3.13.tgz",
                           "dependencies": {
                             "chalk": {
                               "version": "1.1.1",
-                              "from": "chalk@>=1.1.0 <2.0.0",
+                              "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
                               "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
                               "dependencies": {
                                 "ansi-styles": {
                                   "version": "2.1.0",
-                                  "from": "ansi-styles@>=2.1.0 <3.0.0",
+                                  "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz",
                                   "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
                                 },
                                 "escape-string-regexp": {
                                   "version": "1.0.4",
-                                  "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                                  "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz",
                                   "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz"
                                 },
                                 "has-ansi": {
                                   "version": "2.0.0",
-                                  "from": "has-ansi@>=2.0.0 <3.0.0",
+                                  "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                                   "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                                   "dependencies": {
                                     "ansi-regex": {
                                       "version": "2.0.0",
-                                      "from": "ansi-regex@>=2.0.0 <3.0.0",
+                                      "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
                                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                                     }
                                   }
                                 },
                                 "strip-ansi": {
                                   "version": "3.0.0",
-                                  "from": "strip-ansi@>=3.0.0 <4.0.0",
+                                  "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
                                   "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
                                   "dependencies": {
                                     "ansi-regex": {
                                       "version": "2.0.0",
-                                      "from": "ansi-regex@>=2.0.0 <3.0.0",
+                                      "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
                                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                                     }
                                   }
                                 },
                                 "supports-color": {
                                   "version": "2.0.0",
-                                  "from": "supports-color@>=2.0.0 <3.0.0",
+                                  "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
                                   "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
                                 }
                               }
                             },
                             "esutils": {
                               "version": "2.0.2",
-                              "from": "esutils@>=2.0.2 <3.0.0",
+                              "from": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
                               "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
                             },
                             "js-tokens": {
                               "version": "1.0.2",
-                              "from": "js-tokens@>=1.0.1 <2.0.0",
+                              "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz",
                               "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
                             },
                             "line-numbers": {
                               "version": "0.2.0",
-                              "from": "line-numbers@>=0.2.0 <0.3.0",
+                              "from": "https://registry.npmjs.org/line-numbers/-/line-numbers-0.2.0.tgz",
                               "resolved": "https://registry.npmjs.org/line-numbers/-/line-numbers-0.2.0.tgz",
                               "dependencies": {
                                 "left-pad": {
                                   "version": "0.0.3",
-                                  "from": "left-pad@0.0.3",
+                                  "from": "https://registry.npmjs.org/left-pad/-/left-pad-0.0.3.tgz",
                                   "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-0.0.3.tgz"
                                 }
                               }
@@ -1756,44 +1756,44 @@
                         },
                         "babel-messages": {
                           "version": "6.3.18",
-                          "from": "babel-messages@>=6.3.13 <7.0.0",
+                          "from": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.3.18.tgz",
                           "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.3.18.tgz"
                         },
                         "babylon": {
                           "version": "6.4.5",
-                          "from": "babylon@>=6.4.5 <7.0.0",
+                          "from": "https://registry.npmjs.org/babylon/-/babylon-6.4.5.tgz",
                           "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.4.5.tgz"
                         },
                         "debug": {
                           "version": "2.2.0",
-                          "from": "debug@>=2.2.0 <3.0.0",
+                          "from": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
                           "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
                           "dependencies": {
                             "ms": {
                               "version": "0.7.1",
-                              "from": "ms@0.7.1",
+                              "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
                               "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
                             }
                           }
                         },
                         "globals": {
                           "version": "8.18.0",
-                          "from": "globals@>=8.3.0 <9.0.0",
+                          "from": "https://registry.npmjs.org/globals/-/globals-8.18.0.tgz",
                           "resolved": "https://registry.npmjs.org/globals/-/globals-8.18.0.tgz"
                         },
                         "invariant": {
                           "version": "2.2.0",
-                          "from": "invariant@>=2.2.0 <3.0.0",
+                          "from": "https://registry.npmjs.org/invariant/-/invariant-2.2.0.tgz",
                           "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.0.tgz",
                           "dependencies": {
                             "loose-envify": {
                               "version": "1.1.0",
-                              "from": "loose-envify@>=1.0.0 <2.0.0",
+                              "from": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz",
                               "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz",
                               "dependencies": {
                                 "js-tokens": {
                                   "version": "1.0.2",
-                                  "from": "js-tokens@>=1.0.1 <2.0.0",
+                                  "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz",
                                   "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
                                 }
                               }
@@ -1802,17 +1802,17 @@
                         },
                         "repeating": {
                           "version": "1.1.3",
-                          "from": "repeating@>=1.1.3 <2.0.0",
+                          "from": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
                           "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
                           "dependencies": {
                             "is-finite": {
                               "version": "1.0.1",
-                              "from": "is-finite@>=1.0.0 <2.0.0",
+                              "from": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
                               "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
                               "dependencies": {
                                 "number-is-nan": {
                                   "version": "1.0.0",
-                                  "from": "number-is-nan@>=1.0.0 <2.0.0",
+                                  "from": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
                                   "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
                                 }
                               }
@@ -1823,7 +1823,7 @@
                     },
                     "babel-helper-get-function-arity": {
                       "version": "6.3.13",
-                      "from": "babel-helper-get-function-arity@>=6.3.13 <7.0.0",
+                      "from": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.3.13.tgz",
                       "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.3.13.tgz"
                     }
                   }
@@ -1832,88 +1832,88 @@
             },
             "babel-template": {
               "version": "6.3.13",
-              "from": "babel-template@>=6.3.13 <7.0.0",
+              "from": "https://registry.npmjs.org/babel-template/-/babel-template-6.3.13.tgz",
               "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.3.13.tgz",
               "dependencies": {
                 "babylon": {
                   "version": "6.4.5",
-                  "from": "babylon@>=6.3.26 <7.0.0",
+                  "from": "https://registry.npmjs.org/babylon/-/babylon-6.4.5.tgz",
                   "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.4.5.tgz"
                 },
                 "babel-traverse": {
                   "version": "6.4.5",
-                  "from": "babel-traverse@>=6.3.13 <7.0.0",
+                  "from": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.4.5.tgz",
                   "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.4.5.tgz",
                   "dependencies": {
                     "babel-code-frame": {
                       "version": "6.3.13",
-                      "from": "babel-code-frame@>=6.3.13 <7.0.0",
+                      "from": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.3.13.tgz",
                       "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.3.13.tgz",
                       "dependencies": {
                         "chalk": {
                           "version": "1.1.1",
-                          "from": "chalk@>=1.1.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
                           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
                           "dependencies": {
                             "ansi-styles": {
                               "version": "2.1.0",
-                              "from": "ansi-styles@>=2.1.0 <3.0.0",
+                              "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz",
                               "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
                             },
                             "escape-string-regexp": {
                               "version": "1.0.4",
-                              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                              "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz",
                               "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz"
                             },
                             "has-ansi": {
                               "version": "2.0.0",
-                              "from": "has-ansi@>=2.0.0 <3.0.0",
+                              "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                               "dependencies": {
                                 "ansi-regex": {
                                   "version": "2.0.0",
-                                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
                                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                                 }
                               }
                             },
                             "strip-ansi": {
                               "version": "3.0.0",
-                              "from": "strip-ansi@>=3.0.0 <4.0.0",
+                              "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
                               "dependencies": {
                                 "ansi-regex": {
                                   "version": "2.0.0",
-                                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
                                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                                 }
                               }
                             },
                             "supports-color": {
                               "version": "2.0.0",
-                              "from": "supports-color@>=2.0.0 <3.0.0",
+                              "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
                             }
                           }
                         },
                         "esutils": {
                           "version": "2.0.2",
-                          "from": "esutils@>=2.0.2 <3.0.0",
+                          "from": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
                           "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
                         },
                         "js-tokens": {
                           "version": "1.0.2",
-                          "from": "js-tokens@>=1.0.1 <2.0.0",
+                          "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz",
                           "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
                         },
                         "line-numbers": {
                           "version": "0.2.0",
-                          "from": "line-numbers@>=0.2.0 <0.3.0",
+                          "from": "https://registry.npmjs.org/line-numbers/-/line-numbers-0.2.0.tgz",
                           "resolved": "https://registry.npmjs.org/line-numbers/-/line-numbers-0.2.0.tgz",
                           "dependencies": {
                             "left-pad": {
                               "version": "0.0.3",
-                              "from": "left-pad@0.0.3",
+                              "from": "https://registry.npmjs.org/left-pad/-/left-pad-0.0.3.tgz",
                               "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-0.0.3.tgz"
                             }
                           }
@@ -1922,39 +1922,39 @@
                     },
                     "babel-messages": {
                       "version": "6.3.18",
-                      "from": "babel-messages@>=6.3.13 <7.0.0",
+                      "from": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.3.18.tgz",
                       "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.3.18.tgz"
                     },
                     "debug": {
                       "version": "2.2.0",
-                      "from": "debug@>=2.2.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
                       "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
                       "dependencies": {
                         "ms": {
                           "version": "0.7.1",
-                          "from": "ms@0.7.1",
+                          "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
                           "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
                         }
                       }
                     },
                     "globals": {
                       "version": "8.18.0",
-                      "from": "globals@>=8.3.0 <9.0.0",
+                      "from": "https://registry.npmjs.org/globals/-/globals-8.18.0.tgz",
                       "resolved": "https://registry.npmjs.org/globals/-/globals-8.18.0.tgz"
                     },
                     "invariant": {
                       "version": "2.2.0",
-                      "from": "invariant@>=2.2.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/invariant/-/invariant-2.2.0.tgz",
                       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.0.tgz",
                       "dependencies": {
                         "loose-envify": {
                           "version": "1.1.0",
-                          "from": "loose-envify@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz",
                           "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz",
                           "dependencies": {
                             "js-tokens": {
                               "version": "1.0.2",
-                              "from": "js-tokens@>=1.0.1 <2.0.0",
+                              "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz",
                               "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
                             }
                           }
@@ -1963,17 +1963,17 @@
                     },
                     "repeating": {
                       "version": "1.1.3",
-                      "from": "repeating@>=1.1.3 <2.0.0",
+                      "from": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
                       "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
                       "dependencies": {
                         "is-finite": {
                           "version": "1.0.1",
-                          "from": "is-finite@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
                           "dependencies": {
                             "number-is-nan": {
                               "version": "1.0.0",
-                              "from": "number-is-nan@>=1.0.0 <2.0.0",
+                              "from": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
                             }
                           }
@@ -1984,17 +1984,17 @@
                 },
                 "babel-types": {
                   "version": "6.4.5",
-                  "from": "babel-types@>=6.4.3 <7.0.0",
+                  "from": "https://registry.npmjs.org/babel-types/-/babel-types-6.4.5.tgz",
                   "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.4.5.tgz",
                   "dependencies": {
                     "esutils": {
                       "version": "2.0.2",
-                      "from": "esutils@>=2.0.2 <3.0.0",
+                      "from": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
                       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
                     },
                     "to-fast-properties": {
                       "version": "1.0.1",
-                      "from": "to-fast-properties@>=1.0.1 <2.0.0",
+                      "from": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.1.tgz"
                     }
                   }
@@ -2003,12 +2003,12 @@
             },
             "babel-runtime": {
               "version": "5.8.35",
-              "from": "babel-runtime@>=5.0.0 <6.0.0",
+              "from": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.35.tgz",
               "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.35.tgz",
               "dependencies": {
                 "core-js": {
                   "version": "1.2.6",
-                  "from": "core-js@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz",
                   "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
                 }
               }
@@ -2017,17 +2017,17 @@
         },
         "babel-plugin-transform-es2015-for-of": {
           "version": "6.3.13",
-          "from": "babel-plugin-transform-es2015-for-of@>=6.3.13 <7.0.0",
+          "from": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.3.13.tgz",
           "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.3.13.tgz",
           "dependencies": {
             "babel-runtime": {
               "version": "5.8.35",
-              "from": "babel-runtime@>=5.0.0 <6.0.0",
+              "from": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.35.tgz",
               "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.35.tgz",
               "dependencies": {
                 "core-js": {
                   "version": "1.2.6",
-                  "from": "core-js@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz",
                   "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
                 }
               }
@@ -2036,88 +2036,88 @@
         },
         "babel-plugin-transform-es2015-sticky-regex": {
           "version": "6.3.13",
-          "from": "babel-plugin-transform-es2015-sticky-regex@>=6.3.13 <7.0.0",
+          "from": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.3.13.tgz",
           "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.3.13.tgz",
           "dependencies": {
             "babel-helper-regex": {
               "version": "6.3.13",
-              "from": "babel-helper-regex@>=6.3.13 <7.0.0",
+              "from": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.3.13.tgz",
               "resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.3.13.tgz"
             },
             "babel-types": {
               "version": "6.4.5",
-              "from": "babel-types@>=6.4.0 <7.0.0",
+              "from": "https://registry.npmjs.org/babel-types/-/babel-types-6.4.5.tgz",
               "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.4.5.tgz",
               "dependencies": {
                 "babel-traverse": {
                   "version": "6.4.5",
-                  "from": "babel-traverse@>=6.4.5 <7.0.0",
+                  "from": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.4.5.tgz",
                   "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.4.5.tgz",
                   "dependencies": {
                     "babel-code-frame": {
                       "version": "6.3.13",
-                      "from": "babel-code-frame@>=6.3.13 <7.0.0",
+                      "from": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.3.13.tgz",
                       "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.3.13.tgz",
                       "dependencies": {
                         "chalk": {
                           "version": "1.1.1",
-                          "from": "chalk@>=1.1.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
                           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
                           "dependencies": {
                             "ansi-styles": {
                               "version": "2.1.0",
-                              "from": "ansi-styles@>=2.1.0 <3.0.0",
+                              "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz",
                               "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
                             },
                             "escape-string-regexp": {
                               "version": "1.0.4",
-                              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                              "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz",
                               "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz"
                             },
                             "has-ansi": {
                               "version": "2.0.0",
-                              "from": "has-ansi@>=2.0.0 <3.0.0",
+                              "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                               "dependencies": {
                                 "ansi-regex": {
                                   "version": "2.0.0",
-                                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
                                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                                 }
                               }
                             },
                             "strip-ansi": {
                               "version": "3.0.0",
-                              "from": "strip-ansi@>=3.0.0 <4.0.0",
+                              "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
                               "dependencies": {
                                 "ansi-regex": {
                                   "version": "2.0.0",
-                                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
                                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                                 }
                               }
                             },
                             "supports-color": {
                               "version": "2.0.0",
-                              "from": "supports-color@>=2.0.0 <3.0.0",
+                              "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
                             }
                           }
                         },
                         "js-tokens": {
                           "version": "1.0.2",
-                          "from": "js-tokens@>=1.0.1 <2.0.0",
+                          "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz",
                           "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
                         },
                         "line-numbers": {
                           "version": "0.2.0",
-                          "from": "line-numbers@>=0.2.0 <0.3.0",
+                          "from": "https://registry.npmjs.org/line-numbers/-/line-numbers-0.2.0.tgz",
                           "resolved": "https://registry.npmjs.org/line-numbers/-/line-numbers-0.2.0.tgz",
                           "dependencies": {
                             "left-pad": {
                               "version": "0.0.3",
-                              "from": "left-pad@0.0.3",
+                              "from": "https://registry.npmjs.org/left-pad/-/left-pad-0.0.3.tgz",
                               "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-0.0.3.tgz"
                             }
                           }
@@ -2126,44 +2126,44 @@
                     },
                     "babel-messages": {
                       "version": "6.3.18",
-                      "from": "babel-messages@>=6.3.13 <7.0.0",
+                      "from": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.3.18.tgz",
                       "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.3.18.tgz"
                     },
                     "babylon": {
                       "version": "6.4.5",
-                      "from": "babylon@>=6.4.5 <7.0.0",
+                      "from": "https://registry.npmjs.org/babylon/-/babylon-6.4.5.tgz",
                       "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.4.5.tgz"
                     },
                     "debug": {
                       "version": "2.2.0",
-                      "from": "debug@>=2.2.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
                       "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
                       "dependencies": {
                         "ms": {
                           "version": "0.7.1",
-                          "from": "ms@0.7.1",
+                          "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
                           "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
                         }
                       }
                     },
                     "globals": {
                       "version": "8.18.0",
-                      "from": "globals@>=8.3.0 <9.0.0",
+                      "from": "https://registry.npmjs.org/globals/-/globals-8.18.0.tgz",
                       "resolved": "https://registry.npmjs.org/globals/-/globals-8.18.0.tgz"
                     },
                     "invariant": {
                       "version": "2.2.0",
-                      "from": "invariant@>=2.2.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/invariant/-/invariant-2.2.0.tgz",
                       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.0.tgz",
                       "dependencies": {
                         "loose-envify": {
                           "version": "1.1.0",
-                          "from": "loose-envify@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz",
                           "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz",
                           "dependencies": {
                             "js-tokens": {
                               "version": "1.0.2",
-                              "from": "js-tokens@>=1.0.1 <2.0.0",
+                              "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz",
                               "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
                             }
                           }
@@ -2172,17 +2172,17 @@
                     },
                     "repeating": {
                       "version": "1.1.3",
-                      "from": "repeating@>=1.1.3 <2.0.0",
+                      "from": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
                       "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
                       "dependencies": {
                         "is-finite": {
                           "version": "1.0.1",
-                          "from": "is-finite@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
                           "dependencies": {
                             "number-is-nan": {
                               "version": "1.0.0",
-                              "from": "number-is-nan@>=1.0.0 <2.0.0",
+                              "from": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
                             }
                           }
@@ -2193,24 +2193,24 @@
                 },
                 "esutils": {
                   "version": "2.0.2",
-                  "from": "esutils@>=2.0.2 <3.0.0",
+                  "from": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
                 },
                 "to-fast-properties": {
                   "version": "1.0.1",
-                  "from": "to-fast-properties@>=1.0.1 <2.0.0",
+                  "from": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.1.tgz"
                 }
               }
             },
             "babel-runtime": {
               "version": "5.8.35",
-              "from": "babel-runtime@>=5.0.0 <6.0.0",
+              "from": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.35.tgz",
               "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.35.tgz",
               "dependencies": {
                 "core-js": {
                   "version": "1.2.6",
-                  "from": "core-js@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz",
                   "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
                 }
               }
@@ -2219,88 +2219,88 @@
         },
         "babel-plugin-transform-es2015-unicode-regex": {
           "version": "6.4.3",
-          "from": "babel-plugin-transform-es2015-unicode-regex@>=6.3.13 <7.0.0",
+          "from": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.4.3.tgz",
           "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.4.3.tgz",
           "dependencies": {
             "babel-helper-regex": {
               "version": "6.3.13",
-              "from": "babel-helper-regex@>=6.3.13 <7.0.0",
+              "from": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.3.13.tgz",
               "resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.3.13.tgz",
               "dependencies": {
                 "babel-types": {
                   "version": "6.4.5",
-                  "from": "babel-types@>=6.3.13 <7.0.0",
+                  "from": "https://registry.npmjs.org/babel-types/-/babel-types-6.4.5.tgz",
                   "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.4.5.tgz",
                   "dependencies": {
                     "babel-traverse": {
                       "version": "6.4.5",
-                      "from": "babel-traverse@>=6.4.5 <7.0.0",
+                      "from": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.4.5.tgz",
                       "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.4.5.tgz",
                       "dependencies": {
                         "babel-code-frame": {
                           "version": "6.3.13",
-                          "from": "babel-code-frame@>=6.3.13 <7.0.0",
+                          "from": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.3.13.tgz",
                           "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.3.13.tgz",
                           "dependencies": {
                             "chalk": {
                               "version": "1.1.1",
-                              "from": "chalk@>=1.1.0 <2.0.0",
+                              "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
                               "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
                               "dependencies": {
                                 "ansi-styles": {
                                   "version": "2.1.0",
-                                  "from": "ansi-styles@>=2.1.0 <3.0.0",
+                                  "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz",
                                   "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
                                 },
                                 "escape-string-regexp": {
                                   "version": "1.0.4",
-                                  "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                                  "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz",
                                   "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz"
                                 },
                                 "has-ansi": {
                                   "version": "2.0.0",
-                                  "from": "has-ansi@>=2.0.0 <3.0.0",
+                                  "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                                   "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                                   "dependencies": {
                                     "ansi-regex": {
                                       "version": "2.0.0",
-                                      "from": "ansi-regex@>=2.0.0 <3.0.0",
+                                      "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
                                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                                     }
                                   }
                                 },
                                 "strip-ansi": {
                                   "version": "3.0.0",
-                                  "from": "strip-ansi@>=3.0.0 <4.0.0",
+                                  "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
                                   "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
                                   "dependencies": {
                                     "ansi-regex": {
                                       "version": "2.0.0",
-                                      "from": "ansi-regex@>=2.0.0 <3.0.0",
+                                      "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
                                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                                     }
                                   }
                                 },
                                 "supports-color": {
                                   "version": "2.0.0",
-                                  "from": "supports-color@>=2.0.0 <3.0.0",
+                                  "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
                                   "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
                                 }
                               }
                             },
                             "js-tokens": {
                               "version": "1.0.2",
-                              "from": "js-tokens@>=1.0.1 <2.0.0",
+                              "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz",
                               "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
                             },
                             "line-numbers": {
                               "version": "0.2.0",
-                              "from": "line-numbers@>=0.2.0 <0.3.0",
+                              "from": "https://registry.npmjs.org/line-numbers/-/line-numbers-0.2.0.tgz",
                               "resolved": "https://registry.npmjs.org/line-numbers/-/line-numbers-0.2.0.tgz",
                               "dependencies": {
                                 "left-pad": {
                                   "version": "0.0.3",
-                                  "from": "left-pad@0.0.3",
+                                  "from": "https://registry.npmjs.org/left-pad/-/left-pad-0.0.3.tgz",
                                   "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-0.0.3.tgz"
                                 }
                               }
@@ -2309,44 +2309,44 @@
                         },
                         "babel-messages": {
                           "version": "6.3.18",
-                          "from": "babel-messages@>=6.3.13 <7.0.0",
+                          "from": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.3.18.tgz",
                           "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.3.18.tgz"
                         },
                         "babylon": {
                           "version": "6.4.5",
-                          "from": "babylon@>=6.4.5 <7.0.0",
+                          "from": "https://registry.npmjs.org/babylon/-/babylon-6.4.5.tgz",
                           "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.4.5.tgz"
                         },
                         "debug": {
                           "version": "2.2.0",
-                          "from": "debug@>=2.2.0 <3.0.0",
+                          "from": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
                           "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
                           "dependencies": {
                             "ms": {
                               "version": "0.7.1",
-                              "from": "ms@0.7.1",
+                              "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
                               "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
                             }
                           }
                         },
                         "globals": {
                           "version": "8.18.0",
-                          "from": "globals@>=8.3.0 <9.0.0",
+                          "from": "https://registry.npmjs.org/globals/-/globals-8.18.0.tgz",
                           "resolved": "https://registry.npmjs.org/globals/-/globals-8.18.0.tgz"
                         },
                         "invariant": {
                           "version": "2.2.0",
-                          "from": "invariant@>=2.2.0 <3.0.0",
+                          "from": "https://registry.npmjs.org/invariant/-/invariant-2.2.0.tgz",
                           "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.0.tgz",
                           "dependencies": {
                             "loose-envify": {
                               "version": "1.1.0",
-                              "from": "loose-envify@>=1.0.0 <2.0.0",
+                              "from": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz",
                               "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz",
                               "dependencies": {
                                 "js-tokens": {
                                   "version": "1.0.2",
-                                  "from": "js-tokens@>=1.0.1 <2.0.0",
+                                  "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz",
                                   "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
                                 }
                               }
@@ -2355,17 +2355,17 @@
                         },
                         "repeating": {
                           "version": "1.1.3",
-                          "from": "repeating@>=1.1.3 <2.0.0",
+                          "from": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
                           "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
                           "dependencies": {
                             "is-finite": {
                               "version": "1.0.1",
-                              "from": "is-finite@>=1.0.0 <2.0.0",
+                              "from": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
                               "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
                               "dependencies": {
                                 "number-is-nan": {
                                   "version": "1.0.0",
-                                  "from": "number-is-nan@>=1.0.0 <2.0.0",
+                                  "from": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
                                   "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
                                 }
                               }
@@ -2376,12 +2376,12 @@
                     },
                     "esutils": {
                       "version": "2.0.2",
-                      "from": "esutils@>=2.0.2 <3.0.0",
+                      "from": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
                       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
                     },
                     "to-fast-properties": {
                       "version": "1.0.1",
-                      "from": "to-fast-properties@>=1.0.1 <2.0.0",
+                      "from": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.1.tgz"
                     }
                   }
@@ -2390,39 +2390,39 @@
             },
             "babel-runtime": {
               "version": "5.8.35",
-              "from": "babel-runtime@>=5.0.0 <6.0.0",
+              "from": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.35.tgz",
               "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.35.tgz",
               "dependencies": {
                 "core-js": {
                   "version": "1.2.6",
-                  "from": "core-js@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz",
                   "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
                 }
               }
             },
             "regexpu-core": {
               "version": "1.0.0",
-              "from": "regexpu-core@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-1.0.0.tgz",
               "dependencies": {
                 "regenerate": {
                   "version": "1.2.1",
-                  "from": "regenerate@>=1.2.1 <2.0.0",
+                  "from": "https://registry.npmjs.org/regenerate/-/regenerate-1.2.1.tgz",
                   "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.2.1.tgz"
                 },
                 "regjsgen": {
                   "version": "0.2.0",
-                  "from": "regjsgen@>=0.2.0 <0.3.0",
+                  "from": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
                   "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz"
                 },
                 "regjsparser": {
                   "version": "0.1.5",
-                  "from": "regjsparser@>=0.1.4 <0.2.0",
+                  "from": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
                   "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
                   "dependencies": {
                     "jsesc": {
                       "version": "0.5.0",
-                      "from": "jsesc@>=0.5.0 <0.6.0",
+                      "from": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
                       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz"
                     }
                   }
@@ -2433,17 +2433,17 @@
         },
         "babel-plugin-check-es2015-constants": {
           "version": "6.3.13",
-          "from": "babel-plugin-check-es2015-constants@>=6.3.13 <7.0.0",
+          "from": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.3.13.tgz",
           "resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.3.13.tgz",
           "dependencies": {
             "babel-runtime": {
               "version": "5.8.35",
-              "from": "babel-runtime@>=5.0.0 <6.0.0",
+              "from": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.35.tgz",
               "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.35.tgz",
               "dependencies": {
                 "core-js": {
                   "version": "1.2.6",
-                  "from": "core-js@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz",
                   "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
                 }
               }
@@ -2452,17 +2452,17 @@
         },
         "babel-plugin-transform-es2015-spread": {
           "version": "6.4.0",
-          "from": "babel-plugin-transform-es2015-spread@>=6.3.13 <7.0.0",
+          "from": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.4.0.tgz",
           "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.4.0.tgz",
           "dependencies": {
             "babel-runtime": {
               "version": "5.8.35",
-              "from": "babel-runtime@>=5.0.0 <6.0.0",
+              "from": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.35.tgz",
               "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.35.tgz",
               "dependencies": {
                 "core-js": {
                   "version": "1.2.6",
-                  "from": "core-js@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz",
                   "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
                 }
               }
@@ -2471,83 +2471,83 @@
         },
         "babel-plugin-transform-es2015-parameters": {
           "version": "6.4.5",
-          "from": "babel-plugin-transform-es2015-parameters@>=6.3.13 <7.0.0",
+          "from": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.4.5.tgz",
           "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.4.5.tgz",
           "dependencies": {
             "babel-traverse": {
               "version": "6.4.5",
-              "from": "babel-traverse@>=6.4.5 <7.0.0",
+              "from": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.4.5.tgz",
               "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.4.5.tgz",
               "dependencies": {
                 "babel-code-frame": {
                   "version": "6.3.13",
-                  "from": "babel-code-frame@>=6.3.13 <7.0.0",
+                  "from": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.3.13.tgz",
                   "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.3.13.tgz",
                   "dependencies": {
                     "chalk": {
                       "version": "1.1.1",
-                      "from": "chalk@>=1.1.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
                       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
                       "dependencies": {
                         "ansi-styles": {
                           "version": "2.1.0",
-                          "from": "ansi-styles@>=2.1.0 <3.0.0",
+                          "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz",
                           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
                         },
                         "escape-string-regexp": {
                           "version": "1.0.4",
-                          "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                          "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz",
                           "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz"
                         },
                         "has-ansi": {
                           "version": "2.0.0",
-                          "from": "has-ansi@>=2.0.0 <3.0.0",
+                          "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                           "dependencies": {
                             "ansi-regex": {
                               "version": "2.0.0",
-                              "from": "ansi-regex@>=2.0.0 <3.0.0",
+                              "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                             }
                           }
                         },
                         "strip-ansi": {
                           "version": "3.0.0",
-                          "from": "strip-ansi@>=3.0.0 <4.0.0",
+                          "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
                           "dependencies": {
                             "ansi-regex": {
                               "version": "2.0.0",
-                              "from": "ansi-regex@>=2.0.0 <3.0.0",
+                              "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                             }
                           }
                         },
                         "supports-color": {
                           "version": "2.0.0",
-                          "from": "supports-color@>=2.0.0 <3.0.0",
+                          "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
                         }
                       }
                     },
                     "esutils": {
                       "version": "2.0.2",
-                      "from": "esutils@>=2.0.2 <3.0.0",
+                      "from": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
                       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
                     },
                     "js-tokens": {
                       "version": "1.0.2",
-                      "from": "js-tokens@>=1.0.1 <2.0.0",
+                      "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz",
                       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
                     },
                     "line-numbers": {
                       "version": "0.2.0",
-                      "from": "line-numbers@>=0.2.0 <0.3.0",
+                      "from": "https://registry.npmjs.org/line-numbers/-/line-numbers-0.2.0.tgz",
                       "resolved": "https://registry.npmjs.org/line-numbers/-/line-numbers-0.2.0.tgz",
                       "dependencies": {
                         "left-pad": {
                           "version": "0.0.3",
-                          "from": "left-pad@0.0.3",
+                          "from": "https://registry.npmjs.org/left-pad/-/left-pad-0.0.3.tgz",
                           "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-0.0.3.tgz"
                         }
                       }
@@ -2556,44 +2556,44 @@
                 },
                 "babel-messages": {
                   "version": "6.3.18",
-                  "from": "babel-messages@>=6.3.13 <7.0.0",
+                  "from": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.3.18.tgz",
                   "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.3.18.tgz"
                 },
                 "babylon": {
                   "version": "6.4.5",
-                  "from": "babylon@>=6.4.5 <7.0.0",
+                  "from": "https://registry.npmjs.org/babylon/-/babylon-6.4.5.tgz",
                   "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.4.5.tgz"
                 },
                 "debug": {
                   "version": "2.2.0",
-                  "from": "debug@>=2.2.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
                   "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
                   "dependencies": {
                     "ms": {
                       "version": "0.7.1",
-                      "from": "ms@0.7.1",
+                      "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
                       "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
                     }
                   }
                 },
                 "globals": {
                   "version": "8.18.0",
-                  "from": "globals@>=8.3.0 <9.0.0",
+                  "from": "https://registry.npmjs.org/globals/-/globals-8.18.0.tgz",
                   "resolved": "https://registry.npmjs.org/globals/-/globals-8.18.0.tgz"
                 },
                 "invariant": {
                   "version": "2.2.0",
-                  "from": "invariant@>=2.2.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/invariant/-/invariant-2.2.0.tgz",
                   "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.0.tgz",
                   "dependencies": {
                     "loose-envify": {
                       "version": "1.1.0",
-                      "from": "loose-envify@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz",
                       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz",
                       "dependencies": {
                         "js-tokens": {
                           "version": "1.0.2",
-                          "from": "js-tokens@>=1.0.1 <2.0.0",
+                          "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz",
                           "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
                         }
                       }
@@ -2602,17 +2602,17 @@
                 },
                 "repeating": {
                   "version": "1.1.3",
-                  "from": "repeating@>=1.1.3 <2.0.0",
+                  "from": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
                   "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
                   "dependencies": {
                     "is-finite": {
                       "version": "1.0.1",
-                      "from": "is-finite@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
                       "dependencies": {
                         "number-is-nan": {
                           "version": "1.0.0",
-                          "from": "number-is-nan@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
                         }
                       }
@@ -2623,58 +2623,58 @@
             },
             "babel-helper-call-delegate": {
               "version": "6.3.13",
-              "from": "babel-helper-call-delegate@>=6.3.13 <7.0.0",
+              "from": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.3.13.tgz",
               "resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.3.13.tgz",
               "dependencies": {
                 "babel-helper-hoist-variables": {
                   "version": "6.3.13",
-                  "from": "babel-helper-hoist-variables@>=6.3.13 <7.0.0",
+                  "from": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.3.13.tgz",
                   "resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.3.13.tgz"
                 }
               }
             },
             "babel-helper-get-function-arity": {
               "version": "6.3.13",
-              "from": "babel-helper-get-function-arity@>=6.3.13 <7.0.0",
+              "from": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.3.13.tgz",
               "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.3.13.tgz"
             },
             "babel-template": {
               "version": "6.3.13",
-              "from": "babel-template@>=6.3.13 <7.0.0",
+              "from": "https://registry.npmjs.org/babel-template/-/babel-template-6.3.13.tgz",
               "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.3.13.tgz",
               "dependencies": {
                 "babylon": {
                   "version": "6.4.5",
-                  "from": "babylon@>=6.3.13 <7.0.0",
+                  "from": "https://registry.npmjs.org/babylon/-/babylon-6.4.5.tgz",
                   "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.4.5.tgz"
                 }
               }
             },
             "babel-types": {
               "version": "6.4.5",
-              "from": "babel-types@>=6.4.5 <7.0.0",
+              "from": "https://registry.npmjs.org/babel-types/-/babel-types-6.4.5.tgz",
               "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.4.5.tgz",
               "dependencies": {
                 "esutils": {
                   "version": "2.0.2",
-                  "from": "esutils@>=2.0.2 <3.0.0",
+                  "from": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
                 },
                 "to-fast-properties": {
                   "version": "1.0.1",
-                  "from": "to-fast-properties@>=1.0.1 <2.0.0",
+                  "from": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.1.tgz"
                 }
               }
             },
             "babel-runtime": {
               "version": "5.8.35",
-              "from": "babel-runtime@>=5.0.0 <6.0.0",
+              "from": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.35.tgz",
               "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.35.tgz",
               "dependencies": {
                 "core-js": {
                   "version": "1.2.6",
-                  "from": "core-js@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz",
                   "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
                 }
               }
@@ -2683,17 +2683,17 @@
         },
         "babel-plugin-transform-es2015-destructuring": {
           "version": "6.4.0",
-          "from": "babel-plugin-transform-es2015-destructuring@>=6.3.13 <7.0.0",
+          "from": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.4.0.tgz",
           "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.4.0.tgz",
           "dependencies": {
             "babel-runtime": {
               "version": "5.8.35",
-              "from": "babel-runtime@>=5.0.0 <6.0.0",
+              "from": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.35.tgz",
               "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.35.tgz",
               "dependencies": {
                 "core-js": {
                   "version": "1.2.6",
-                  "from": "core-js@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz",
                   "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
                 }
               }
@@ -2702,83 +2702,83 @@
         },
         "babel-plugin-transform-es2015-block-scoping": {
           "version": "6.4.0",
-          "from": "babel-plugin-transform-es2015-block-scoping@>=6.3.13 <7.0.0",
+          "from": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.4.0.tgz",
           "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.4.0.tgz",
           "dependencies": {
             "babel-traverse": {
               "version": "6.4.5",
-              "from": "babel-traverse@>=6.3.13 <7.0.0",
+              "from": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.4.5.tgz",
               "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.4.5.tgz",
               "dependencies": {
                 "babel-code-frame": {
                   "version": "6.3.13",
-                  "from": "babel-code-frame@>=6.3.13 <7.0.0",
+                  "from": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.3.13.tgz",
                   "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.3.13.tgz",
                   "dependencies": {
                     "chalk": {
                       "version": "1.1.1",
-                      "from": "chalk@>=1.1.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
                       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
                       "dependencies": {
                         "ansi-styles": {
                           "version": "2.1.0",
-                          "from": "ansi-styles@>=2.1.0 <3.0.0",
+                          "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz",
                           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
                         },
                         "escape-string-regexp": {
                           "version": "1.0.4",
-                          "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                          "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz",
                           "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz"
                         },
                         "has-ansi": {
                           "version": "2.0.0",
-                          "from": "has-ansi@>=2.0.0 <3.0.0",
+                          "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                           "dependencies": {
                             "ansi-regex": {
                               "version": "2.0.0",
-                              "from": "ansi-regex@>=2.0.0 <3.0.0",
+                              "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                             }
                           }
                         },
                         "strip-ansi": {
                           "version": "3.0.0",
-                          "from": "strip-ansi@>=3.0.0 <4.0.0",
+                          "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
                           "dependencies": {
                             "ansi-regex": {
                               "version": "2.0.0",
-                              "from": "ansi-regex@>=2.0.0 <3.0.0",
+                              "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                             }
                           }
                         },
                         "supports-color": {
                           "version": "2.0.0",
-                          "from": "supports-color@>=2.0.0 <3.0.0",
+                          "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
                         }
                       }
                     },
                     "esutils": {
                       "version": "2.0.2",
-                      "from": "esutils@>=2.0.2 <3.0.0",
+                      "from": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
                       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
                     },
                     "js-tokens": {
                       "version": "1.0.2",
-                      "from": "js-tokens@>=1.0.1 <2.0.0",
+                      "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz",
                       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
                     },
                     "line-numbers": {
                       "version": "0.2.0",
-                      "from": "line-numbers@>=0.2.0 <0.3.0",
+                      "from": "https://registry.npmjs.org/line-numbers/-/line-numbers-0.2.0.tgz",
                       "resolved": "https://registry.npmjs.org/line-numbers/-/line-numbers-0.2.0.tgz",
                       "dependencies": {
                         "left-pad": {
                           "version": "0.0.3",
-                          "from": "left-pad@0.0.3",
+                          "from": "https://registry.npmjs.org/left-pad/-/left-pad-0.0.3.tgz",
                           "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-0.0.3.tgz"
                         }
                       }
@@ -2787,44 +2787,44 @@
                 },
                 "babel-messages": {
                   "version": "6.3.18",
-                  "from": "babel-messages@>=6.3.13 <7.0.0",
+                  "from": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.3.18.tgz",
                   "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.3.18.tgz"
                 },
                 "babylon": {
                   "version": "6.4.5",
-                  "from": "babylon@>=6.4.5 <7.0.0",
+                  "from": "https://registry.npmjs.org/babylon/-/babylon-6.4.5.tgz",
                   "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.4.5.tgz"
                 },
                 "debug": {
                   "version": "2.2.0",
-                  "from": "debug@>=2.2.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
                   "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
                   "dependencies": {
                     "ms": {
                       "version": "0.7.1",
-                      "from": "ms@0.7.1",
+                      "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
                       "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
                     }
                   }
                 },
                 "globals": {
                   "version": "8.18.0",
-                  "from": "globals@>=8.3.0 <9.0.0",
+                  "from": "https://registry.npmjs.org/globals/-/globals-8.18.0.tgz",
                   "resolved": "https://registry.npmjs.org/globals/-/globals-8.18.0.tgz"
                 },
                 "invariant": {
                   "version": "2.2.0",
-                  "from": "invariant@>=2.2.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/invariant/-/invariant-2.2.0.tgz",
                   "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.0.tgz",
                   "dependencies": {
                     "loose-envify": {
                       "version": "1.1.0",
-                      "from": "loose-envify@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz",
                       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz",
                       "dependencies": {
                         "js-tokens": {
                           "version": "1.0.2",
-                          "from": "js-tokens@>=1.0.1 <2.0.0",
+                          "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz",
                           "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
                         }
                       }
@@ -2833,17 +2833,17 @@
                 },
                 "repeating": {
                   "version": "1.1.3",
-                  "from": "repeating@>=1.1.3 <2.0.0",
+                  "from": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
                   "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
                   "dependencies": {
                     "is-finite": {
                       "version": "1.0.1",
-                      "from": "is-finite@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
                       "dependencies": {
                         "number-is-nan": {
                           "version": "1.0.0",
-                          "from": "number-is-nan@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
                         }
                       }
@@ -2854,41 +2854,41 @@
             },
             "babel-types": {
               "version": "6.4.5",
-              "from": "babel-types@>=6.4.0 <7.0.0",
+              "from": "https://registry.npmjs.org/babel-types/-/babel-types-6.4.5.tgz",
               "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.4.5.tgz",
               "dependencies": {
                 "esutils": {
                   "version": "2.0.2",
-                  "from": "esutils@>=2.0.2 <3.0.0",
+                  "from": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
                 },
                 "to-fast-properties": {
                   "version": "1.0.1",
-                  "from": "to-fast-properties@>=1.0.1 <2.0.0",
+                  "from": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.1.tgz"
                 }
               }
             },
             "babel-template": {
               "version": "6.3.13",
-              "from": "babel-template@>=6.3.13 <7.0.0",
+              "from": "https://registry.npmjs.org/babel-template/-/babel-template-6.3.13.tgz",
               "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.3.13.tgz",
               "dependencies": {
                 "babylon": {
                   "version": "6.4.5",
-                  "from": "babylon@>=6.3.13 <7.0.0",
+                  "from": "https://registry.npmjs.org/babylon/-/babylon-6.4.5.tgz",
                   "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.4.5.tgz"
                 }
               }
             },
             "babel-runtime": {
               "version": "5.8.35",
-              "from": "babel-runtime@>=5.0.0 <6.0.0",
+              "from": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.35.tgz",
               "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.35.tgz",
               "dependencies": {
                 "core-js": {
                   "version": "1.2.6",
-                  "from": "core-js@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz",
                   "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
                 }
               }
@@ -2897,17 +2897,17 @@
         },
         "babel-plugin-transform-es2015-typeof-symbol": {
           "version": "6.4.3",
-          "from": "babel-plugin-transform-es2015-typeof-symbol@>=6.3.13 <7.0.0",
+          "from": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.4.3.tgz",
           "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.4.3.tgz",
           "dependencies": {
             "babel-runtime": {
               "version": "5.8.35",
-              "from": "babel-runtime@>=5.0.0 <6.0.0",
+              "from": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.35.tgz",
               "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.35.tgz",
               "dependencies": {
                 "core-js": {
                   "version": "1.2.6",
-                  "from": "core-js@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz",
                   "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
                 }
               }
@@ -2916,83 +2916,83 @@
         },
         "babel-plugin-transform-es2015-modules-commonjs": {
           "version": "6.4.5",
-          "from": "babel-plugin-transform-es2015-modules-commonjs@>=6.3.13 <7.0.0",
+          "from": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.4.5.tgz",
           "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.4.5.tgz",
           "dependencies": {
             "babel-types": {
               "version": "6.4.5",
-              "from": "babel-types@>=6.4.0 <7.0.0",
+              "from": "https://registry.npmjs.org/babel-types/-/babel-types-6.4.5.tgz",
               "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.4.5.tgz",
               "dependencies": {
                 "babel-traverse": {
                   "version": "6.4.5",
-                  "from": "babel-traverse@>=6.4.5 <7.0.0",
+                  "from": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.4.5.tgz",
                   "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.4.5.tgz",
                   "dependencies": {
                     "babel-code-frame": {
                       "version": "6.3.13",
-                      "from": "babel-code-frame@>=6.3.13 <7.0.0",
+                      "from": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.3.13.tgz",
                       "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.3.13.tgz",
                       "dependencies": {
                         "chalk": {
                           "version": "1.1.1",
-                          "from": "chalk@>=1.1.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
                           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
                           "dependencies": {
                             "ansi-styles": {
                               "version": "2.1.0",
-                              "from": "ansi-styles@>=2.1.0 <3.0.0",
+                              "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz",
                               "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
                             },
                             "escape-string-regexp": {
                               "version": "1.0.4",
-                              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                              "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz",
                               "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz"
                             },
                             "has-ansi": {
                               "version": "2.0.0",
-                              "from": "has-ansi@>=2.0.0 <3.0.0",
+                              "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                               "dependencies": {
                                 "ansi-regex": {
                                   "version": "2.0.0",
-                                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
                                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                                 }
                               }
                             },
                             "strip-ansi": {
                               "version": "3.0.0",
-                              "from": "strip-ansi@>=3.0.0 <4.0.0",
+                              "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
                               "dependencies": {
                                 "ansi-regex": {
                                   "version": "2.0.0",
-                                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
                                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                                 }
                               }
                             },
                             "supports-color": {
                               "version": "2.0.0",
-                              "from": "supports-color@>=2.0.0 <3.0.0",
+                              "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
                             }
                           }
                         },
                         "js-tokens": {
                           "version": "1.0.2",
-                          "from": "js-tokens@>=1.0.1 <2.0.0",
+                          "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz",
                           "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
                         },
                         "line-numbers": {
                           "version": "0.2.0",
-                          "from": "line-numbers@>=0.2.0 <0.3.0",
+                          "from": "https://registry.npmjs.org/line-numbers/-/line-numbers-0.2.0.tgz",
                           "resolved": "https://registry.npmjs.org/line-numbers/-/line-numbers-0.2.0.tgz",
                           "dependencies": {
                             "left-pad": {
                               "version": "0.0.3",
-                              "from": "left-pad@0.0.3",
+                              "from": "https://registry.npmjs.org/left-pad/-/left-pad-0.0.3.tgz",
                               "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-0.0.3.tgz"
                             }
                           }
@@ -3001,44 +3001,44 @@
                     },
                     "babel-messages": {
                       "version": "6.3.18",
-                      "from": "babel-messages@>=6.3.13 <7.0.0",
+                      "from": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.3.18.tgz",
                       "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.3.18.tgz"
                     },
                     "babylon": {
                       "version": "6.4.5",
-                      "from": "babylon@>=6.4.5 <7.0.0",
+                      "from": "https://registry.npmjs.org/babylon/-/babylon-6.4.5.tgz",
                       "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.4.5.tgz"
                     },
                     "debug": {
                       "version": "2.2.0",
-                      "from": "debug@>=2.2.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
                       "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
                       "dependencies": {
                         "ms": {
                           "version": "0.7.1",
-                          "from": "ms@0.7.1",
+                          "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
                           "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
                         }
                       }
                     },
                     "globals": {
                       "version": "8.18.0",
-                      "from": "globals@>=8.3.0 <9.0.0",
+                      "from": "https://registry.npmjs.org/globals/-/globals-8.18.0.tgz",
                       "resolved": "https://registry.npmjs.org/globals/-/globals-8.18.0.tgz"
                     },
                     "invariant": {
                       "version": "2.2.0",
-                      "from": "invariant@>=2.2.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/invariant/-/invariant-2.2.0.tgz",
                       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.0.tgz",
                       "dependencies": {
                         "loose-envify": {
                           "version": "1.1.0",
-                          "from": "loose-envify@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz",
                           "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz",
                           "dependencies": {
                             "js-tokens": {
                               "version": "1.0.2",
-                              "from": "js-tokens@>=1.0.1 <2.0.0",
+                              "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz",
                               "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
                             }
                           }
@@ -3047,17 +3047,17 @@
                     },
                     "repeating": {
                       "version": "1.1.3",
-                      "from": "repeating@>=1.1.3 <2.0.0",
+                      "from": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
                       "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
                       "dependencies": {
                         "is-finite": {
                           "version": "1.0.1",
-                          "from": "is-finite@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
                           "dependencies": {
                             "number-is-nan": {
                               "version": "1.0.0",
-                              "from": "number-is-nan@>=1.0.0 <2.0.0",
+                              "from": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
                             }
                           }
@@ -3068,112 +3068,112 @@
                 },
                 "esutils": {
                   "version": "2.0.2",
-                  "from": "esutils@>=2.0.2 <3.0.0",
+                  "from": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
                 },
                 "to-fast-properties": {
                   "version": "1.0.1",
-                  "from": "to-fast-properties@>=1.0.1 <2.0.0",
+                  "from": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.1.tgz"
                 }
               }
             },
             "babel-runtime": {
               "version": "5.8.35",
-              "from": "babel-runtime@>=5.0.0 <6.0.0",
+              "from": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.35.tgz",
               "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.35.tgz",
               "dependencies": {
                 "core-js": {
                   "version": "1.2.6",
-                  "from": "core-js@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz",
                   "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
                 }
               }
             },
             "babel-template": {
               "version": "6.3.13",
-              "from": "babel-template@>=6.3.13 <7.0.0",
+              "from": "https://registry.npmjs.org/babel-template/-/babel-template-6.3.13.tgz",
               "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.3.13.tgz",
               "dependencies": {
                 "babylon": {
                   "version": "6.4.5",
-                  "from": "babylon@>=6.3.13 <7.0.0",
+                  "from": "https://registry.npmjs.org/babylon/-/babylon-6.4.5.tgz",
                   "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.4.5.tgz"
                 },
                 "babel-traverse": {
                   "version": "6.4.5",
-                  "from": "babel-traverse@>=6.3.13 <7.0.0",
+                  "from": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.4.5.tgz",
                   "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.4.5.tgz",
                   "dependencies": {
                     "babel-code-frame": {
                       "version": "6.3.13",
-                      "from": "babel-code-frame@>=6.3.13 <7.0.0",
+                      "from": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.3.13.tgz",
                       "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.3.13.tgz",
                       "dependencies": {
                         "chalk": {
                           "version": "1.1.1",
-                          "from": "chalk@>=1.1.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
                           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
                           "dependencies": {
                             "ansi-styles": {
                               "version": "2.1.0",
-                              "from": "ansi-styles@>=2.1.0 <3.0.0",
+                              "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz",
                               "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
                             },
                             "escape-string-regexp": {
                               "version": "1.0.4",
-                              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                              "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz",
                               "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz"
                             },
                             "has-ansi": {
                               "version": "2.0.0",
-                              "from": "has-ansi@>=2.0.0 <3.0.0",
+                              "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                               "dependencies": {
                                 "ansi-regex": {
                                   "version": "2.0.0",
-                                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
                                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                                 }
                               }
                             },
                             "strip-ansi": {
                               "version": "3.0.0",
-                              "from": "strip-ansi@>=3.0.0 <4.0.0",
+                              "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
                               "dependencies": {
                                 "ansi-regex": {
                                   "version": "2.0.0",
-                                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
                                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                                 }
                               }
                             },
                             "supports-color": {
                               "version": "2.0.0",
-                              "from": "supports-color@>=2.0.0 <3.0.0",
+                              "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
                             }
                           }
                         },
                         "esutils": {
                           "version": "2.0.2",
-                          "from": "esutils@>=2.0.2 <3.0.0",
+                          "from": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
                           "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
                         },
                         "js-tokens": {
                           "version": "1.0.2",
-                          "from": "js-tokens@>=1.0.1 <2.0.0",
+                          "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz",
                           "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
                         },
                         "line-numbers": {
                           "version": "0.2.0",
-                          "from": "line-numbers@>=0.2.0 <0.3.0",
+                          "from": "https://registry.npmjs.org/line-numbers/-/line-numbers-0.2.0.tgz",
                           "resolved": "https://registry.npmjs.org/line-numbers/-/line-numbers-0.2.0.tgz",
                           "dependencies": {
                             "left-pad": {
                               "version": "0.0.3",
-                              "from": "left-pad@0.0.3",
+                              "from": "https://registry.npmjs.org/left-pad/-/left-pad-0.0.3.tgz",
                               "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-0.0.3.tgz"
                             }
                           }
@@ -3182,39 +3182,39 @@
                     },
                     "babel-messages": {
                       "version": "6.3.18",
-                      "from": "babel-messages@>=6.3.13 <7.0.0",
+                      "from": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.3.18.tgz",
                       "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.3.18.tgz"
                     },
                     "debug": {
                       "version": "2.2.0",
-                      "from": "debug@>=2.2.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
                       "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
                       "dependencies": {
                         "ms": {
                           "version": "0.7.1",
-                          "from": "ms@0.7.1",
+                          "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
                           "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
                         }
                       }
                     },
                     "globals": {
                       "version": "8.18.0",
-                      "from": "globals@>=8.3.0 <9.0.0",
+                      "from": "https://registry.npmjs.org/globals/-/globals-8.18.0.tgz",
                       "resolved": "https://registry.npmjs.org/globals/-/globals-8.18.0.tgz"
                     },
                     "invariant": {
                       "version": "2.2.0",
-                      "from": "invariant@>=2.2.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/invariant/-/invariant-2.2.0.tgz",
                       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.0.tgz",
                       "dependencies": {
                         "loose-envify": {
                           "version": "1.1.0",
-                          "from": "loose-envify@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz",
                           "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz",
                           "dependencies": {
                             "js-tokens": {
                               "version": "1.0.2",
-                              "from": "js-tokens@>=1.0.1 <2.0.0",
+                              "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz",
                               "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
                             }
                           }
@@ -3223,17 +3223,17 @@
                     },
                     "repeating": {
                       "version": "1.1.3",
-                      "from": "repeating@>=1.1.3 <2.0.0",
+                      "from": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
                       "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
                       "dependencies": {
                         "is-finite": {
                           "version": "1.0.1",
-                          "from": "is-finite@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
                           "dependencies": {
                             "number-is-nan": {
                               "version": "1.0.0",
-                              "from": "number-is-nan@>=1.0.0 <2.0.0",
+                              "from": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
                             }
                           }
@@ -3246,107 +3246,107 @@
             },
             "babel-plugin-transform-strict-mode": {
               "version": "6.3.13",
-              "from": "babel-plugin-transform-strict-mode@>=6.3.13 <7.0.0",
+              "from": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.3.13.tgz",
               "resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.3.13.tgz"
             }
           }
         },
         "babel-plugin-transform-regenerator": {
           "version": "6.4.4",
-          "from": "babel-plugin-transform-regenerator@>=6.3.13 <7.0.0",
+          "from": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.4.4.tgz",
           "resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.4.4.tgz",
           "dependencies": {
             "babel-plugin-syntax-async-functions": {
               "version": "6.3.13",
-              "from": "babel-plugin-syntax-async-functions@>=6.3.13 <7.0.0",
+              "from": "https://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.3.13.tgz",
               "resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.3.13.tgz"
             },
             "babel-runtime": {
               "version": "5.8.35",
-              "from": "babel-runtime@>=5.0.0 <6.0.0",
+              "from": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.35.tgz",
               "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.35.tgz",
               "dependencies": {
                 "core-js": {
                   "version": "1.2.6",
-                  "from": "core-js@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz",
                   "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
                 }
               }
             },
             "babel-traverse": {
               "version": "6.4.5",
-              "from": "babel-traverse@>=6.3.26 <7.0.0",
+              "from": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.4.5.tgz",
               "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.4.5.tgz",
               "dependencies": {
                 "babel-code-frame": {
                   "version": "6.3.13",
-                  "from": "babel-code-frame@>=6.3.13 <7.0.0",
+                  "from": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.3.13.tgz",
                   "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.3.13.tgz",
                   "dependencies": {
                     "chalk": {
                       "version": "1.1.1",
-                      "from": "chalk@>=1.1.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
                       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
                       "dependencies": {
                         "ansi-styles": {
                           "version": "2.1.0",
-                          "from": "ansi-styles@>=2.1.0 <3.0.0",
+                          "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz",
                           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
                         },
                         "escape-string-regexp": {
                           "version": "1.0.4",
-                          "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                          "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz",
                           "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz"
                         },
                         "has-ansi": {
                           "version": "2.0.0",
-                          "from": "has-ansi@>=2.0.0 <3.0.0",
+                          "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                           "dependencies": {
                             "ansi-regex": {
                               "version": "2.0.0",
-                              "from": "ansi-regex@>=2.0.0 <3.0.0",
+                              "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                             }
                           }
                         },
                         "strip-ansi": {
                           "version": "3.0.0",
-                          "from": "strip-ansi@>=3.0.0 <4.0.0",
+                          "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
                           "dependencies": {
                             "ansi-regex": {
                               "version": "2.0.0",
-                              "from": "ansi-regex@>=2.0.0 <3.0.0",
+                              "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                             }
                           }
                         },
                         "supports-color": {
                           "version": "2.0.0",
-                          "from": "supports-color@>=2.0.0 <3.0.0",
+                          "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
                         }
                       }
                     },
                     "esutils": {
                       "version": "2.0.2",
-                      "from": "esutils@>=2.0.2 <3.0.0",
+                      "from": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
                       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
                     },
                     "js-tokens": {
                       "version": "1.0.2",
-                      "from": "js-tokens@>=1.0.1 <2.0.0",
+                      "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz",
                       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
                     },
                     "line-numbers": {
                       "version": "0.2.0",
-                      "from": "line-numbers@>=0.2.0 <0.3.0",
+                      "from": "https://registry.npmjs.org/line-numbers/-/line-numbers-0.2.0.tgz",
                       "resolved": "https://registry.npmjs.org/line-numbers/-/line-numbers-0.2.0.tgz",
                       "dependencies": {
                         "left-pad": {
                           "version": "0.0.3",
-                          "from": "left-pad@0.0.3",
+                          "from": "https://registry.npmjs.org/left-pad/-/left-pad-0.0.3.tgz",
                           "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-0.0.3.tgz"
                         }
                       }
@@ -3355,39 +3355,39 @@
                 },
                 "babel-messages": {
                   "version": "6.3.18",
-                  "from": "babel-messages@>=6.3.13 <7.0.0",
+                  "from": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.3.18.tgz",
                   "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.3.18.tgz"
                 },
                 "debug": {
                   "version": "2.2.0",
-                  "from": "debug@>=2.2.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
                   "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
                   "dependencies": {
                     "ms": {
                       "version": "0.7.1",
-                      "from": "ms@0.7.1",
+                      "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
                       "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
                     }
                   }
                 },
                 "globals": {
                   "version": "8.18.0",
-                  "from": "globals@>=8.3.0 <9.0.0",
+                  "from": "https://registry.npmjs.org/globals/-/globals-8.18.0.tgz",
                   "resolved": "https://registry.npmjs.org/globals/-/globals-8.18.0.tgz"
                 },
                 "invariant": {
                   "version": "2.2.0",
-                  "from": "invariant@>=2.2.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/invariant/-/invariant-2.2.0.tgz",
                   "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.0.tgz",
                   "dependencies": {
                     "loose-envify": {
                       "version": "1.1.0",
-                      "from": "loose-envify@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz",
                       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz",
                       "dependencies": {
                         "js-tokens": {
                           "version": "1.0.2",
-                          "from": "js-tokens@>=1.0.1 <2.0.0",
+                          "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz",
                           "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
                         }
                       }
@@ -3396,17 +3396,17 @@
                 },
                 "repeating": {
                   "version": "1.1.3",
-                  "from": "repeating@>=1.1.3 <2.0.0",
+                  "from": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
                   "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
                   "dependencies": {
                     "is-finite": {
                       "version": "1.0.1",
-                      "from": "is-finite@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
                       "dependencies": {
                         "number-is-nan": {
                           "version": "1.0.0",
-                          "from": "number-is-nan@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
                         }
                       }
@@ -3417,29 +3417,29 @@
             },
             "babel-types": {
               "version": "6.4.5",
-              "from": "babel-types@>=6.4.3 <7.0.0",
+              "from": "https://registry.npmjs.org/babel-types/-/babel-types-6.4.5.tgz",
               "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.4.5.tgz",
               "dependencies": {
                 "esutils": {
                   "version": "2.0.2",
-                  "from": "esutils@>=2.0.2 <3.0.0",
+                  "from": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
                 },
                 "to-fast-properties": {
                   "version": "1.0.1",
-                  "from": "to-fast-properties@>=1.0.1 <2.0.0",
+                  "from": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.1.tgz"
                 }
               }
             },
             "babylon": {
               "version": "6.4.5",
-              "from": "babylon@>=6.3.26 <7.0.0",
+              "from": "https://registry.npmjs.org/babylon/-/babylon-6.4.5.tgz",
               "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.4.5.tgz"
             },
             "private": {
               "version": "0.1.6",
-              "from": "private@>=0.1.5 <0.2.0",
+              "from": "https://registry.npmjs.org/private/-/private-0.1.6.tgz",
               "resolved": "https://registry.npmjs.org/private/-/private-0.1.6.tgz"
             }
           }
@@ -3448,22 +3448,22 @@
     },
     "babel-preset-react": {
       "version": "6.3.13",
-      "from": "babel-preset-react@>=6.1.2 <7.0.0",
+      "from": "https://registry.npmjs.org/babel-preset-react/-/babel-preset-react-6.3.13.tgz",
       "resolved": "https://registry.npmjs.org/babel-preset-react/-/babel-preset-react-6.3.13.tgz",
       "dependencies": {
         "babel-plugin-syntax-flow": {
           "version": "6.3.13",
-          "from": "babel-plugin-syntax-flow@>=6.3.13 <7.0.0",
+          "from": "https://registry.npmjs.org/babel-plugin-syntax-flow/-/babel-plugin-syntax-flow-6.3.13.tgz",
           "resolved": "https://registry.npmjs.org/babel-plugin-syntax-flow/-/babel-plugin-syntax-flow-6.3.13.tgz",
           "dependencies": {
             "babel-runtime": {
               "version": "5.8.35",
-              "from": "babel-runtime@>=5.0.0 <6.0.0",
+              "from": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.35.tgz",
               "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.35.tgz",
               "dependencies": {
                 "core-js": {
                   "version": "1.2.6",
-                  "from": "core-js@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz",
                   "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
                 }
               }
@@ -3472,17 +3472,17 @@
         },
         "babel-plugin-syntax-jsx": {
           "version": "6.3.13",
-          "from": "babel-plugin-syntax-jsx@>=6.3.13 <7.0.0",
+          "from": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.3.13.tgz",
           "resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.3.13.tgz",
           "dependencies": {
             "babel-runtime": {
               "version": "5.8.35",
-              "from": "babel-runtime@>=5.0.0 <6.0.0",
+              "from": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.35.tgz",
               "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.35.tgz",
               "dependencies": {
                 "core-js": {
                   "version": "1.2.6",
-                  "from": "core-js@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz",
                   "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
                 }
               }
@@ -3491,17 +3491,17 @@
         },
         "babel-plugin-transform-flow-strip-types": {
           "version": "6.4.0",
-          "from": "babel-plugin-transform-flow-strip-types@>=6.3.13 <7.0.0",
+          "from": "https://registry.npmjs.org/babel-plugin-transform-flow-strip-types/-/babel-plugin-transform-flow-strip-types-6.4.0.tgz",
           "resolved": "https://registry.npmjs.org/babel-plugin-transform-flow-strip-types/-/babel-plugin-transform-flow-strip-types-6.4.0.tgz",
           "dependencies": {
             "babel-runtime": {
               "version": "5.8.35",
-              "from": "babel-runtime@>=5.0.0 <6.0.0",
+              "from": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.35.tgz",
               "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.35.tgz",
               "dependencies": {
                 "core-js": {
                   "version": "1.2.6",
-                  "from": "core-js@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz",
                   "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
                 }
               }
@@ -3510,17 +3510,17 @@
         },
         "babel-plugin-transform-react-display-name": {
           "version": "6.4.0",
-          "from": "babel-plugin-transform-react-display-name@>=6.3.13 <7.0.0",
+          "from": "https://registry.npmjs.org/babel-plugin-transform-react-display-name/-/babel-plugin-transform-react-display-name-6.4.0.tgz",
           "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-display-name/-/babel-plugin-transform-react-display-name-6.4.0.tgz",
           "dependencies": {
             "babel-runtime": {
               "version": "5.8.35",
-              "from": "babel-runtime@>=5.0.0 <6.0.0",
+              "from": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.35.tgz",
               "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.35.tgz",
               "dependencies": {
                 "core-js": {
                   "version": "1.2.6",
-                  "from": "core-js@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz",
                   "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
                 }
               }
@@ -3529,17 +3529,17 @@
         },
         "babel-plugin-transform-react-jsx-source": {
           "version": "6.3.13",
-          "from": "babel-plugin-transform-react-jsx-source@>=6.3.13 <7.0.0",
+          "from": "https://registry.npmjs.org/babel-plugin-transform-react-jsx-source/-/babel-plugin-transform-react-jsx-source-6.3.13.tgz",
           "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-jsx-source/-/babel-plugin-transform-react-jsx-source-6.3.13.tgz",
           "dependencies": {
             "babel-runtime": {
               "version": "5.8.35",
-              "from": "babel-runtime@>=5.0.0 <6.0.0",
+              "from": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.35.tgz",
               "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.35.tgz",
               "dependencies": {
                 "core-js": {
                   "version": "1.2.6",
-                  "from": "core-js@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz",
                   "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
                 }
               }
@@ -3550,108 +3550,108 @@
     },
     "bourbon-neat": {
       "version": "1.7.2",
-      "from": "bourbon-neat@>=1.7.2 <2.0.0",
+      "from": "https://registry.npmjs.org/bourbon-neat/-/bourbon-neat-1.7.2.tgz",
       "resolved": "https://registry.npmjs.org/bourbon-neat/-/bourbon-neat-1.7.2.tgz"
     },
     "css-loader": {
       "version": "0.22.0",
-      "from": "css-loader@>=0.22.0 <0.23.0",
+      "from": "https://registry.npmjs.org/css-loader/-/css-loader-0.22.0.tgz",
       "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-0.22.0.tgz",
       "dependencies": {
         "css-selector-tokenizer": {
           "version": "0.5.4",
-          "from": "css-selector-tokenizer@>=0.5.1 <0.6.0",
+          "from": "https://registry.npmjs.org/css-selector-tokenizer/-/css-selector-tokenizer-0.5.4.tgz",
           "resolved": "https://registry.npmjs.org/css-selector-tokenizer/-/css-selector-tokenizer-0.5.4.tgz",
           "dependencies": {
             "cssesc": {
               "version": "0.1.0",
-              "from": "cssesc@>=0.1.0 <0.2.0",
+              "from": "https://registry.npmjs.org/cssesc/-/cssesc-0.1.0.tgz",
               "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-0.1.0.tgz"
             },
             "fastparse": {
               "version": "1.1.1",
-              "from": "fastparse@>=1.1.1 <2.0.0",
+              "from": "https://registry.npmjs.org/fastparse/-/fastparse-1.1.1.tgz",
               "resolved": "https://registry.npmjs.org/fastparse/-/fastparse-1.1.1.tgz"
             }
           }
         },
         "cssnano": {
           "version": "3.4.0",
-          "from": "cssnano@>=2.6.1 <4.0.0",
+          "from": "https://registry.npmjs.org/cssnano/-/cssnano-3.4.0.tgz",
           "resolved": "https://registry.npmjs.org/cssnano/-/cssnano-3.4.0.tgz",
           "dependencies": {
             "autoprefixer": {
               "version": "6.3.1",
-              "from": "autoprefixer@>=6.0.3 <7.0.0",
+              "from": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-6.3.1.tgz",
               "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-6.3.1.tgz",
               "dependencies": {
                 "normalize-range": {
                   "version": "0.1.2",
-                  "from": "normalize-range@>=0.1.2 <0.2.0",
+                  "from": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
                   "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz"
                 },
                 "num2fraction": {
                   "version": "1.2.2",
-                  "from": "num2fraction@>=1.2.2 <2.0.0",
+                  "from": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.2.2.tgz",
                   "resolved": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.2.2.tgz"
                 },
                 "browserslist": {
                   "version": "1.1.1",
-                  "from": "browserslist@>=1.1.1 <1.2.0",
+                  "from": "https://registry.npmjs.org/browserslist/-/browserslist-1.1.1.tgz",
                   "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.1.1.tgz"
                 },
                 "caniuse-db": {
                   "version": "1.0.30000406",
-                  "from": "caniuse-db@>=1.0.30000387 <2.0.0",
+                  "from": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000406.tgz",
                   "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000406.tgz"
                 }
               }
             },
             "decamelize": {
               "version": "1.1.2",
-              "from": "decamelize@>=1.1.0 <2.0.0",
+              "from": "https://registry.npmjs.org/decamelize/-/decamelize-1.1.2.tgz",
               "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.1.2.tgz",
               "dependencies": {
                 "escape-string-regexp": {
                   "version": "1.0.4",
-                  "from": "escape-string-regexp@>=1.0.4 <2.0.0",
+                  "from": "escape-string-regexp@>=1.0.2 <2.0.0",
                   "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz"
                 }
               }
             },
             "defined": {
               "version": "1.0.0",
-              "from": "defined@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz"
             },
             "indexes-of": {
               "version": "1.0.1",
-              "from": "indexes-of@>=1.0.1 <2.0.0",
+              "from": "https://registry.npmjs.org/indexes-of/-/indexes-of-1.0.1.tgz",
               "resolved": "https://registry.npmjs.org/indexes-of/-/indexes-of-1.0.1.tgz"
             },
             "postcss-calc": {
               "version": "5.2.0",
-              "from": "postcss-calc@>=5.0.0 <6.0.0",
+              "from": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-5.2.0.tgz",
               "resolved": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-5.2.0.tgz",
               "dependencies": {
                 "postcss-message-helpers": {
                   "version": "2.0.0",
-                  "from": "postcss-message-helpers@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/postcss-message-helpers/-/postcss-message-helpers-2.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/postcss-message-helpers/-/postcss-message-helpers-2.0.0.tgz"
                 },
                 "reduce-css-calc": {
                   "version": "1.2.0",
-                  "from": "reduce-css-calc@>=1.2.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/reduce-css-calc/-/reduce-css-calc-1.2.0.tgz",
                   "resolved": "https://registry.npmjs.org/reduce-css-calc/-/reduce-css-calc-1.2.0.tgz",
                   "dependencies": {
                     "balanced-match": {
                       "version": "0.1.0",
-                      "from": "balanced-match@>=0.1.0 <0.2.0",
+                      "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.1.0.tgz",
                       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.1.0.tgz"
                     },
                     "reduce-function-call": {
                       "version": "1.0.1",
-                      "from": "reduce-function-call@>=1.0.1 <2.0.0",
+                      "from": "https://registry.npmjs.org/reduce-function-call/-/reduce-function-call-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/reduce-function-call/-/reduce-function-call-1.0.1.tgz"
                     }
                   }
@@ -3660,32 +3660,32 @@
             },
             "postcss-colormin": {
               "version": "2.1.8",
-              "from": "postcss-colormin@>=2.1.7 <3.0.0",
+              "from": "https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-2.1.8.tgz",
               "resolved": "https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-2.1.8.tgz",
               "dependencies": {
                 "colormin": {
                   "version": "1.0.7",
-                  "from": "colormin@>=1.0.5 <2.0.0",
+                  "from": "https://registry.npmjs.org/colormin/-/colormin-1.0.7.tgz",
                   "resolved": "https://registry.npmjs.org/colormin/-/colormin-1.0.7.tgz",
                   "dependencies": {
                     "color": {
                       "version": "0.11.1",
-                      "from": "color@>=0.11.0 <0.12.0",
+                      "from": "https://registry.npmjs.org/color/-/color-0.11.1.tgz",
                       "resolved": "https://registry.npmjs.org/color/-/color-0.11.1.tgz",
                       "dependencies": {
                         "color-convert": {
                           "version": "0.5.3",
-                          "from": "color-convert@>=0.5.3 <0.6.0",
+                          "from": "https://registry.npmjs.org/color-convert/-/color-convert-0.5.3.tgz",
                           "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-0.5.3.tgz"
                         },
                         "color-string": {
                           "version": "0.3.0",
-                          "from": "color-string@>=0.3.0 <0.4.0",
+                          "from": "https://registry.npmjs.org/color-string/-/color-string-0.3.0.tgz",
                           "resolved": "https://registry.npmjs.org/color-string/-/color-string-0.3.0.tgz",
                           "dependencies": {
                             "color-name": {
                               "version": "1.1.1",
-                              "from": "color-name@>=1.0.0 <2.0.0",
+                              "from": "https://registry.npmjs.org/color-name/-/color-name-1.1.1.tgz",
                               "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.1.tgz"
                             }
                           }
@@ -3694,7 +3694,7 @@
                     },
                     "css-color-names": {
                       "version": "0.0.3",
-                      "from": "css-color-names@0.0.3",
+                      "from": "https://registry.npmjs.org/css-color-names/-/css-color-names-0.0.3.tgz",
                       "resolved": "https://registry.npmjs.org/css-color-names/-/css-color-names-0.0.3.tgz"
                     }
                   }
@@ -3703,132 +3703,132 @@
             },
             "postcss-convert-values": {
               "version": "2.3.4",
-              "from": "postcss-convert-values@>=2.3.4 <3.0.0",
+              "from": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-2.3.4.tgz",
               "resolved": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-2.3.4.tgz"
             },
             "postcss-discard-comments": {
               "version": "2.0.3",
-              "from": "postcss-discard-comments@>=2.0.2 <3.0.0",
+              "from": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-2.0.3.tgz",
               "resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-2.0.3.tgz"
             },
             "postcss-discard-duplicates": {
               "version": "2.0.0",
-              "from": "postcss-discard-duplicates@>=2.0.0 <3.0.0",
+              "from": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-2.0.0.tgz",
               "resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-2.0.0.tgz"
             },
             "postcss-discard-empty": {
               "version": "2.0.0",
-              "from": "postcss-discard-empty@>=2.0.0 <3.0.0",
+              "from": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-2.0.0.tgz",
               "resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-2.0.0.tgz"
             },
             "postcss-discard-unused": {
               "version": "2.2.0",
-              "from": "postcss-discard-unused@>=2.1.0 <3.0.0",
+              "from": "https://registry.npmjs.org/postcss-discard-unused/-/postcss-discard-unused-2.2.0.tgz",
               "resolved": "https://registry.npmjs.org/postcss-discard-unused/-/postcss-discard-unused-2.2.0.tgz",
               "dependencies": {
                 "flatten": {
                   "version": "1.0.2",
-                  "from": "flatten@1.0.2",
+                  "from": "https://registry.npmjs.org/flatten/-/flatten-1.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/flatten/-/flatten-1.0.2.tgz"
                 },
                 "uniqs": {
                   "version": "2.0.0",
-                  "from": "uniqs@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz"
                 }
               }
             },
             "postcss-filter-plugins": {
               "version": "2.0.0",
-              "from": "postcss-filter-plugins@>=2.0.0 <3.0.0",
+              "from": "https://registry.npmjs.org/postcss-filter-plugins/-/postcss-filter-plugins-2.0.0.tgz",
               "resolved": "https://registry.npmjs.org/postcss-filter-plugins/-/postcss-filter-plugins-2.0.0.tgz",
               "dependencies": {
                 "uniqid": {
                   "version": "1.0.0",
-                  "from": "uniqid@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/uniqid/-/uniqid-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/uniqid/-/uniqid-1.0.0.tgz"
                 }
               }
             },
             "postcss-merge-idents": {
               "version": "2.1.4",
-              "from": "postcss-merge-idents@>=2.1.3 <3.0.0",
+              "from": "https://registry.npmjs.org/postcss-merge-idents/-/postcss-merge-idents-2.1.4.tgz",
               "resolved": "https://registry.npmjs.org/postcss-merge-idents/-/postcss-merge-idents-2.1.4.tgz",
               "dependencies": {
                 "has-own": {
                   "version": "1.0.0",
-                  "from": "has-own@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/has-own/-/has-own-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/has-own/-/has-own-1.0.0.tgz"
                 }
               }
             },
             "postcss-merge-longhand": {
               "version": "2.0.1",
-              "from": "postcss-merge-longhand@>=2.0.1 <3.0.0",
+              "from": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-2.0.1.tgz",
               "resolved": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-2.0.1.tgz"
             },
             "postcss-merge-rules": {
               "version": "2.0.3",
-              "from": "postcss-merge-rules@>=2.0.1 <3.0.0",
+              "from": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-2.0.3.tgz",
               "resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-2.0.3.tgz"
             },
             "postcss-minify-font-values": {
               "version": "1.0.2",
-              "from": "postcss-minify-font-values@>=1.0.2 <2.0.0",
+              "from": "https://registry.npmjs.org/postcss-minify-font-values/-/postcss-minify-font-values-1.0.2.tgz",
               "resolved": "https://registry.npmjs.org/postcss-minify-font-values/-/postcss-minify-font-values-1.0.2.tgz",
               "dependencies": {
                 "uniqs": {
                   "version": "2.0.0",
-                  "from": "uniqs@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz"
                 }
               }
             },
             "postcss-minify-gradients": {
               "version": "1.0.1",
-              "from": "postcss-minify-gradients@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-1.0.1.tgz",
               "resolved": "https://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-1.0.1.tgz"
             },
             "postcss-minify-params": {
               "version": "1.0.4",
-              "from": "postcss-minify-params@>=1.0.4 <2.0.0",
+              "from": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-1.0.4.tgz",
               "resolved": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-1.0.4.tgz",
               "dependencies": {
                 "alphanum-sort": {
                   "version": "1.0.2",
-                  "from": "alphanum-sort@>=1.0.2 <2.0.0",
+                  "from": "https://registry.npmjs.org/alphanum-sort/-/alphanum-sort-1.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/alphanum-sort/-/alphanum-sort-1.0.2.tgz"
                 },
                 "uniqs": {
                   "version": "2.0.0",
-                  "from": "uniqs@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz"
                 }
               }
             },
             "postcss-minify-selectors": {
               "version": "2.0.3",
-              "from": "postcss-minify-selectors@>=2.0.1 <3.0.0",
+              "from": "https://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-2.0.3.tgz",
               "resolved": "https://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-2.0.3.tgz",
               "dependencies": {
                 "alphanum-sort": {
                   "version": "1.0.2",
-                  "from": "alphanum-sort@>=1.0.2 <2.0.0",
+                  "from": "https://registry.npmjs.org/alphanum-sort/-/alphanum-sort-1.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/alphanum-sort/-/alphanum-sort-1.0.2.tgz"
                 },
                 "postcss-selector-parser": {
                   "version": "1.3.1",
-                  "from": "postcss-selector-parser@>=1.3.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-1.3.1.tgz",
                   "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-1.3.1.tgz",
                   "dependencies": {
                     "flatten": {
                       "version": "1.0.2",
-                      "from": "flatten@>=1.0.2 <2.0.0",
+                      "from": "https://registry.npmjs.org/flatten/-/flatten-1.0.2.tgz",
                       "resolved": "https://registry.npmjs.org/flatten/-/flatten-1.0.2.tgz"
                     },
                     "uniq": {
                       "version": "1.0.1",
-                      "from": "uniq@>=1.0.1 <2.0.0",
+                      "from": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz"
                     }
                   }
@@ -3837,49 +3837,49 @@
             },
             "postcss-normalize-charset": {
               "version": "1.1.0",
-              "from": "postcss-normalize-charset@>=1.1.0 <2.0.0",
+              "from": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-1.1.0.tgz",
               "resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-1.1.0.tgz"
             },
             "postcss-normalize-url": {
               "version": "3.0.5",
-              "from": "postcss-normalize-url@>=3.0.4 <4.0.0",
+              "from": "https://registry.npmjs.org/postcss-normalize-url/-/postcss-normalize-url-3.0.5.tgz",
               "resolved": "https://registry.npmjs.org/postcss-normalize-url/-/postcss-normalize-url-3.0.5.tgz",
               "dependencies": {
                 "is-absolute-url": {
                   "version": "2.0.0",
-                  "from": "is-absolute-url@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-2.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-2.0.0.tgz"
                 },
                 "normalize-url": {
                   "version": "1.4.0",
-                  "from": "normalize-url@>=1.3.1 <2.0.0",
+                  "from": "https://registry.npmjs.org/normalize-url/-/normalize-url-1.4.0.tgz",
                   "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-1.4.0.tgz",
                   "dependencies": {
                     "prepend-http": {
                       "version": "1.0.3",
-                      "from": "prepend-http@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.3.tgz",
                       "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.3.tgz"
                     },
                     "query-string": {
                       "version": "3.0.0",
-                      "from": "query-string@>=3.0.0 <4.0.0",
+                      "from": "https://registry.npmjs.org/query-string/-/query-string-3.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/query-string/-/query-string-3.0.0.tgz",
                       "dependencies": {
                         "strict-uri-encode": {
                           "version": "1.1.0",
-                          "from": "strict-uri-encode@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
                           "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz"
                         }
                       }
                     },
                     "sort-keys": {
                       "version": "1.1.1",
-                      "from": "sort-keys@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.1.tgz",
                       "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.1.tgz",
                       "dependencies": {
                         "is-plain-obj": {
                           "version": "1.1.0",
-                          "from": "is-plain-obj@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
                           "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz"
                         }
                       }
@@ -3890,159 +3890,159 @@
             },
             "postcss-ordered-values": {
               "version": "2.0.2",
-              "from": "postcss-ordered-values@>=2.0.2 <3.0.0",
+              "from": "https://registry.npmjs.org/postcss-ordered-values/-/postcss-ordered-values-2.0.2.tgz",
               "resolved": "https://registry.npmjs.org/postcss-ordered-values/-/postcss-ordered-values-2.0.2.tgz"
             },
             "postcss-reduce-idents": {
               "version": "2.2.1",
-              "from": "postcss-reduce-idents@>=2.2.1 <3.0.0",
+              "from": "https://registry.npmjs.org/postcss-reduce-idents/-/postcss-reduce-idents-2.2.1.tgz",
               "resolved": "https://registry.npmjs.org/postcss-reduce-idents/-/postcss-reduce-idents-2.2.1.tgz"
             },
             "postcss-reduce-transforms": {
               "version": "1.0.3",
-              "from": "postcss-reduce-transforms@>=1.0.3 <2.0.0",
+              "from": "https://registry.npmjs.org/postcss-reduce-transforms/-/postcss-reduce-transforms-1.0.3.tgz",
               "resolved": "https://registry.npmjs.org/postcss-reduce-transforms/-/postcss-reduce-transforms-1.0.3.tgz"
             },
             "postcss-svgo": {
               "version": "2.1.1",
-              "from": "postcss-svgo@>=2.0.4 <3.0.0",
+              "from": "https://registry.npmjs.org/postcss-svgo/-/postcss-svgo-2.1.1.tgz",
               "resolved": "https://registry.npmjs.org/postcss-svgo/-/postcss-svgo-2.1.1.tgz",
               "dependencies": {
                 "is-svg": {
                   "version": "1.1.1",
-                  "from": "is-svg@>=1.1.1 <2.0.0",
+                  "from": "https://registry.npmjs.org/is-svg/-/is-svg-1.1.1.tgz",
                   "resolved": "https://registry.npmjs.org/is-svg/-/is-svg-1.1.1.tgz"
                 },
                 "svgo": {
                   "version": "0.6.1",
-                  "from": "svgo@>=0.6.1 <0.7.0",
+                  "from": "https://registry.npmjs.org/svgo/-/svgo-0.6.1.tgz",
                   "resolved": "https://registry.npmjs.org/svgo/-/svgo-0.6.1.tgz",
                   "dependencies": {
                     "sax": {
                       "version": "1.1.5",
-                      "from": "sax@>=1.1.4 <1.2.0",
+                      "from": "https://registry.npmjs.org/sax/-/sax-1.1.5.tgz",
                       "resolved": "https://registry.npmjs.org/sax/-/sax-1.1.5.tgz"
                     },
                     "coa": {
                       "version": "1.0.1",
-                      "from": "coa@>=1.0.1 <1.1.0",
+                      "from": "https://registry.npmjs.org/coa/-/coa-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/coa/-/coa-1.0.1.tgz",
                       "dependencies": {
                         "q": {
                           "version": "1.4.1",
-                          "from": "q@>=1.1.2 <2.0.0",
+                          "from": "https://registry.npmjs.org/q/-/q-1.4.1.tgz",
                           "resolved": "https://registry.npmjs.org/q/-/q-1.4.1.tgz"
                         }
                       }
                     },
                     "js-yaml": {
                       "version": "3.4.6",
-                      "from": "js-yaml@>=3.4.3 <3.5.0",
+                      "from": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.4.6.tgz",
                       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.4.6.tgz",
                       "dependencies": {
                         "argparse": {
                           "version": "1.0.4",
-                          "from": "argparse@>=1.0.2 <2.0.0",
+                          "from": "https://registry.npmjs.org/argparse/-/argparse-1.0.4.tgz",
                           "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.4.tgz",
                           "dependencies": {
                             "lodash": {
                               "version": "4.2.1",
-                              "from": "lodash@>=4.0.0 <5.0.0",
+                              "from": "https://registry.npmjs.org/lodash/-/lodash-4.2.1.tgz",
                               "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.2.1.tgz"
                             },
                             "sprintf-js": {
                               "version": "1.0.3",
-                              "from": "sprintf-js@>=1.0.2 <1.1.0",
+                              "from": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
                               "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz"
                             }
                           }
                         },
                         "esprima": {
                           "version": "2.7.2",
-                          "from": "esprima@>=2.6.0 <3.0.0",
+                          "from": "https://registry.npmjs.org/esprima/-/esprima-2.7.2.tgz",
                           "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.2.tgz"
                         },
                         "inherit": {
                           "version": "2.2.3",
-                          "from": "inherit@>=2.2.2 <3.0.0",
+                          "from": "https://registry.npmjs.org/inherit/-/inherit-2.2.3.tgz",
                           "resolved": "https://registry.npmjs.org/inherit/-/inherit-2.2.3.tgz"
                         }
                       }
                     },
                     "colors": {
                       "version": "1.1.2",
-                      "from": "colors@>=1.1.2 <1.2.0",
+                      "from": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
                       "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz"
                     },
                     "whet.extend": {
                       "version": "0.9.9",
-                      "from": "whet.extend@>=0.9.9 <0.10.0",
+                      "from": "https://registry.npmjs.org/whet.extend/-/whet.extend-0.9.9.tgz",
                       "resolved": "https://registry.npmjs.org/whet.extend/-/whet.extend-0.9.9.tgz"
                     },
                     "mkdirp": {
                       "version": "0.5.1",
-                      "from": "mkdirp@>=0.5.1 <0.6.0",
+                      "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
                       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
                       "dependencies": {
                         "minimist": {
                           "version": "0.0.8",
-                          "from": "minimist@0.0.8",
+                          "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
                           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
                         }
                       }
                     },
                     "csso": {
                       "version": "1.4.4",
-                      "from": "csso@>=1.4.2 <1.5.0",
+                      "from": "https://registry.npmjs.org/csso/-/csso-1.4.4.tgz",
                       "resolved": "https://registry.npmjs.org/csso/-/csso-1.4.4.tgz",
                       "dependencies": {
                         "clap": {
                           "version": "1.0.10",
-                          "from": "clap@>=1.0.9 <2.0.0",
+                          "from": "https://registry.npmjs.org/clap/-/clap-1.0.10.tgz",
                           "resolved": "https://registry.npmjs.org/clap/-/clap-1.0.10.tgz",
                           "dependencies": {
                             "chalk": {
                               "version": "1.1.1",
-                              "from": "chalk@1.1.1",
+                              "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
                               "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
                               "dependencies": {
                                 "ansi-styles": {
                                   "version": "2.1.0",
-                                  "from": "ansi-styles@>=2.1.0 <3.0.0",
+                                  "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz",
                                   "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
                                 },
                                 "escape-string-regexp": {
                                   "version": "1.0.4",
-                                  "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                                  "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz",
                                   "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz"
                                 },
                                 "has-ansi": {
                                   "version": "2.0.0",
-                                  "from": "has-ansi@>=2.0.0 <3.0.0",
+                                  "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                                   "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                                   "dependencies": {
                                     "ansi-regex": {
                                       "version": "2.0.0",
-                                      "from": "ansi-regex@>=2.0.0 <3.0.0",
+                                      "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
                                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                                     }
                                   }
                                 },
                                 "strip-ansi": {
                                   "version": "3.0.0",
-                                  "from": "strip-ansi@>=3.0.0 <4.0.0",
+                                  "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
                                   "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
                                   "dependencies": {
                                     "ansi-regex": {
                                       "version": "2.0.0",
-                                      "from": "ansi-regex@>=2.0.0 <3.0.0",
+                                      "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
                                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                                     }
                                   }
                                 },
                                 "supports-color": {
                                   "version": "2.0.0",
-                                  "from": "supports-color@>=2.0.0 <3.0.0",
+                                  "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
                                   "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
                                 }
                               }
@@ -4057,34 +4057,34 @@
             },
             "postcss-unique-selectors": {
               "version": "2.0.1",
-              "from": "postcss-unique-selectors@>=2.0.1 <3.0.0",
+              "from": "https://registry.npmjs.org/postcss-unique-selectors/-/postcss-unique-selectors-2.0.1.tgz",
               "resolved": "https://registry.npmjs.org/postcss-unique-selectors/-/postcss-unique-selectors-2.0.1.tgz",
               "dependencies": {
                 "alphanum-sort": {
                   "version": "1.0.2",
-                  "from": "alphanum-sort@>=1.0.2 <2.0.0",
+                  "from": "https://registry.npmjs.org/alphanum-sort/-/alphanum-sort-1.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/alphanum-sort/-/alphanum-sort-1.0.2.tgz"
                 },
                 "uniqs": {
                   "version": "2.0.0",
-                  "from": "uniqs@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz"
                 }
               }
             },
             "postcss-value-parser": {
               "version": "3.2.3",
-              "from": "postcss-value-parser@>=3.1.1 <4.0.0",
+              "from": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.2.3.tgz",
               "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.2.3.tgz"
             },
             "postcss-zindex": {
               "version": "2.0.1",
-              "from": "postcss-zindex@>=2.0.0 <3.0.0",
+              "from": "https://registry.npmjs.org/postcss-zindex/-/postcss-zindex-2.0.1.tgz",
               "resolved": "https://registry.npmjs.org/postcss-zindex/-/postcss-zindex-2.0.1.tgz",
               "dependencies": {
                 "uniqs": {
                   "version": "2.0.0",
-                  "from": "uniqs@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz"
                 }
               }
@@ -4093,44 +4093,44 @@
         },
         "loader-utils": {
           "version": "0.2.12",
-          "from": "loader-utils@>=0.2.2 <0.3.0",
+          "from": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.12.tgz",
           "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.12.tgz",
           "dependencies": {
             "big.js": {
               "version": "3.1.3",
-              "from": "big.js@>=3.0.2 <4.0.0",
+              "from": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz",
               "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz"
             },
             "json5": {
               "version": "0.4.0",
-              "from": "json5@>=0.4.0 <0.5.0",
+              "from": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz",
               "resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz"
             }
           }
         },
         "object-assign": {
           "version": "4.0.1",
-          "from": "object-assign@>=4.0.1 <5.0.0",
+          "from": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz",
           "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz"
         },
         "lodash.camelcase": {
           "version": "3.0.1",
-          "from": "lodash.camelcase@>=3.0.1 <4.0.0",
+          "from": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-3.0.1.tgz",
           "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-3.0.1.tgz",
           "dependencies": {
             "lodash._createcompounder": {
               "version": "3.0.0",
-              "from": "lodash._createcompounder@>=3.0.0 <4.0.0",
+              "from": "https://registry.npmjs.org/lodash._createcompounder/-/lodash._createcompounder-3.0.0.tgz",
               "resolved": "https://registry.npmjs.org/lodash._createcompounder/-/lodash._createcompounder-3.0.0.tgz",
               "dependencies": {
                 "lodash.deburr": {
                   "version": "3.1.2",
-                  "from": "lodash.deburr@>=3.0.0 <4.0.0",
+                  "from": "https://registry.npmjs.org/lodash.deburr/-/lodash.deburr-3.1.2.tgz",
                   "resolved": "https://registry.npmjs.org/lodash.deburr/-/lodash.deburr-3.1.2.tgz"
                 },
                 "lodash.words": {
                   "version": "3.1.2",
-                  "from": "lodash.words@>=3.0.0 <4.0.0",
+                  "from": "https://registry.npmjs.org/lodash.words/-/lodash.words-3.1.2.tgz",
                   "resolved": "https://registry.npmjs.org/lodash.words/-/lodash.words-3.1.2.tgz"
                 }
               }
@@ -4139,95 +4139,95 @@
         },
         "postcss": {
           "version": "5.0.14",
-          "from": "postcss@>=5.0.6 <6.0.0",
+          "from": "https://registry.npmjs.org/postcss/-/postcss-5.0.14.tgz",
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.0.14.tgz",
           "dependencies": {
             "supports-color": {
               "version": "3.1.2",
-              "from": "supports-color@>=3.1.2 <4.0.0",
+              "from": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
               "dependencies": {
                 "has-flag": {
                   "version": "1.0.0",
-                  "from": "has-flag@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
                 }
               }
             },
             "source-map": {
               "version": "0.5.3",
-              "from": "source-map@>=0.5.1 <0.6.0",
+              "from": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz",
               "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz"
             },
             "js-base64": {
               "version": "2.1.9",
-              "from": "js-base64@>=2.1.9 <3.0.0",
+              "from": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz",
               "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz"
             }
           }
         },
         "postcss-modules-extract-imports": {
           "version": "1.0.0-beta2",
-          "from": "postcss-modules-extract-imports@1.0.0-beta2",
+          "from": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-1.0.0-beta2.tgz",
           "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-1.0.0-beta2.tgz"
         },
         "postcss-modules-local-by-default": {
           "version": "1.0.1",
-          "from": "postcss-modules-local-by-default@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-1.0.1.tgz",
           "resolved": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-1.0.1.tgz"
         },
         "postcss-modules-scope": {
           "version": "1.0.0-beta2",
-          "from": "postcss-modules-scope@1.0.0-beta2",
+          "from": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-1.0.0-beta2.tgz",
           "resolved": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-1.0.0-beta2.tgz"
         },
         "postcss-modules-values": {
           "version": "1.1.1",
-          "from": "postcss-modules-values@>=1.1.0 <2.0.0",
+          "from": "https://registry.npmjs.org/postcss-modules-values/-/postcss-modules-values-1.1.1.tgz",
           "resolved": "https://registry.npmjs.org/postcss-modules-values/-/postcss-modules-values-1.1.1.tgz",
           "dependencies": {
             "icss-replace-symbols": {
               "version": "1.0.2",
-              "from": "icss-replace-symbols@>=1.0.2 <2.0.0",
+              "from": "https://registry.npmjs.org/icss-replace-symbols/-/icss-replace-symbols-1.0.2.tgz",
               "resolved": "https://registry.npmjs.org/icss-replace-symbols/-/icss-replace-symbols-1.0.2.tgz"
             }
           }
         },
         "source-list-map": {
           "version": "0.1.5",
-          "from": "source-list-map@>=0.1.4 <0.2.0",
+          "from": "https://registry.npmjs.org/source-list-map/-/source-list-map-0.1.5.tgz",
           "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-0.1.5.tgz"
         }
       }
     },
     "es6-promise": {
       "version": "3.0.2",
-      "from": "es6-promise@>=3.0.2 <4.0.0",
+      "from": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.0.2.tgz",
       "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.0.2.tgz"
     },
     "history": {
       "version": "1.17.0",
-      "from": "history@>=1.17.0 <2.0.0",
+      "from": "https://registry.npmjs.org/history/-/history-1.17.0.tgz",
       "resolved": "https://registry.npmjs.org/history/-/history-1.17.0.tgz",
       "dependencies": {
         "deep-equal": {
           "version": "1.0.1",
-          "from": "deep-equal@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
           "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz"
         },
         "invariant": {
           "version": "2.2.0",
-          "from": "invariant@>=2.0.0 <3.0.0",
+          "from": "https://registry.npmjs.org/invariant/-/invariant-2.2.0.tgz",
           "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.0.tgz",
           "dependencies": {
             "loose-envify": {
               "version": "1.1.0",
-              "from": "loose-envify@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz",
               "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz",
               "dependencies": {
                 "js-tokens": {
                   "version": "1.0.2",
-                  "from": "js-tokens@>=1.0.1 <2.0.0",
+                  "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
                 }
               }
@@ -4236,29 +4236,29 @@
         },
         "query-string": {
           "version": "3.0.0",
-          "from": "query-string@>=3.0.0 <4.0.0",
+          "from": "https://registry.npmjs.org/query-string/-/query-string-3.0.0.tgz",
           "resolved": "https://registry.npmjs.org/query-string/-/query-string-3.0.0.tgz",
           "dependencies": {
             "strict-uri-encode": {
               "version": "1.1.0",
-              "from": "strict-uri-encode@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
               "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz"
             }
           }
         },
         "warning": {
           "version": "2.1.0",
-          "from": "warning@>=2.0.0 <3.0.0",
+          "from": "https://registry.npmjs.org/warning/-/warning-2.1.0.tgz",
           "resolved": "https://registry.npmjs.org/warning/-/warning-2.1.0.tgz",
           "dependencies": {
             "loose-envify": {
               "version": "1.1.0",
-              "from": "loose-envify@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz",
               "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz",
               "dependencies": {
                 "js-tokens": {
                   "version": "1.0.2",
-                  "from": "js-tokens@>=1.0.1 <2.0.0",
+                  "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
                 }
               }
@@ -4269,7 +4269,7 @@
     },
     "isomorphic-fetch": {
       "version": "2.2.1",
-      "from": "isomorphic-fetch@>=2.2.0 <2.3.0",
+      "from": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
       "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
       "dependencies": {
         "node-fetch": {
@@ -4293,100 +4293,100 @@
         },
         "whatwg-fetch": {
           "version": "0.11.0",
-          "from": "whatwg-fetch@>=0.10.0",
+          "from": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-0.11.0.tgz",
           "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-0.11.0.tgz"
         }
       }
     },
     "jsx-loader": {
       "version": "0.13.2",
-      "from": "jsx-loader@>=0.13.2 <0.14.0",
+      "from": "https://registry.npmjs.org/jsx-loader/-/jsx-loader-0.13.2.tgz",
       "resolved": "https://registry.npmjs.org/jsx-loader/-/jsx-loader-0.13.2.tgz",
       "dependencies": {
         "jstransform": {
           "version": "11.0.3",
-          "from": "jstransform@>=11.0.0 <12.0.0",
+          "from": "https://registry.npmjs.org/jstransform/-/jstransform-11.0.3.tgz",
           "resolved": "https://registry.npmjs.org/jstransform/-/jstransform-11.0.3.tgz",
           "dependencies": {
             "base62": {
               "version": "1.1.0",
-              "from": "base62@>=1.1.0 <2.0.0",
+              "from": "https://registry.npmjs.org/base62/-/base62-1.1.0.tgz",
               "resolved": "https://registry.npmjs.org/base62/-/base62-1.1.0.tgz"
             },
             "commoner": {
               "version": "0.10.4",
-              "from": "commoner@>=0.10.1 <0.11.0",
+              "from": "https://registry.npmjs.org/commoner/-/commoner-0.10.4.tgz",
               "resolved": "https://registry.npmjs.org/commoner/-/commoner-0.10.4.tgz",
               "dependencies": {
                 "commander": {
                   "version": "2.9.0",
-                  "from": "commander@>=2.5.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
                   "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
                   "dependencies": {
                     "graceful-readlink": {
                       "version": "1.0.1",
-                      "from": "graceful-readlink@>=1.0.0",
+                      "from": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
                     }
                   }
                 },
                 "detective": {
                   "version": "4.3.1",
-                  "from": "detective@>=4.3.1 <5.0.0",
+                  "from": "https://registry.npmjs.org/detective/-/detective-4.3.1.tgz",
                   "resolved": "https://registry.npmjs.org/detective/-/detective-4.3.1.tgz",
                   "dependencies": {
                     "acorn": {
                       "version": "1.2.2",
-                      "from": "acorn@>=1.0.3 <2.0.0",
+                      "from": "https://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz",
                       "resolved": "https://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz"
                     },
                     "defined": {
                       "version": "1.0.0",
-                      "from": "defined@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz"
                     }
                   }
                 },
                 "glob": {
                   "version": "5.0.15",
-                  "from": "glob@>=5.0.15 <6.0.0",
+                  "from": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
                   "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
                   "dependencies": {
                     "inflight": {
                       "version": "1.0.4",
-                      "from": "inflight@>=1.0.4 <2.0.0",
+                      "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
                       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
                       "dependencies": {
                         "wrappy": {
                           "version": "1.0.1",
-                          "from": "wrappy@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                         }
                       }
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@>=2.0.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     },
                     "minimatch": {
                       "version": "3.0.0",
-                      "from": "minimatch@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0",
+                      "from": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
                       "dependencies": {
                         "brace-expansion": {
                           "version": "1.1.2",
-                          "from": "brace-expansion@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.2.tgz",
                           "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.2.tgz",
                           "dependencies": {
                             "balanced-match": {
                               "version": "0.3.0",
-                              "from": "balanced-match@>=0.3.0 <0.4.0",
+                              "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz",
                               "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
                             },
                             "concat-map": {
                               "version": "0.0.1",
-                              "from": "concat-map@0.0.1",
+                              "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
                               "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                             }
                           }
@@ -4400,26 +4400,26 @@
                       "dependencies": {
                         "wrappy": {
                           "version": "1.0.1",
-                          "from": "wrappy@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                         }
                       }
                     },
                     "path-is-absolute": {
                       "version": "1.0.0",
-                      "from": "path-is-absolute@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
                     }
                   }
                 },
                 "graceful-fs": {
                   "version": "4.1.3",
-                  "from": "graceful-fs@>=4.1.2 <5.0.0",
+                  "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz",
                   "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz"
                 },
                 "iconv-lite": {
                   "version": "0.4.13",
-                  "from": "iconv-lite@>=0.4.5 <0.5.0",
+                  "from": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz",
                   "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz"
                 },
                 "mkdirp": {
@@ -4429,39 +4429,39 @@
                   "dependencies": {
                     "minimist": {
                       "version": "0.0.8",
-                      "from": "minimist@0.0.8",
+                      "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
                       "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
                     }
                   }
                 },
                 "private": {
                   "version": "0.1.6",
-                  "from": "private@>=0.1.6 <0.2.0",
+                  "from": "https://registry.npmjs.org/private/-/private-0.1.6.tgz",
                   "resolved": "https://registry.npmjs.org/private/-/private-0.1.6.tgz"
                 },
                 "q": {
                   "version": "1.4.1",
-                  "from": "q@>=1.1.2 <2.0.0",
+                  "from": "https://registry.npmjs.org/q/-/q-1.4.1.tgz",
                   "resolved": "https://registry.npmjs.org/q/-/q-1.4.1.tgz"
                 },
                 "recast": {
                   "version": "0.10.43",
-                  "from": "recast@>=0.10.0 <0.11.0",
+                  "from": "https://registry.npmjs.org/recast/-/recast-0.10.43.tgz",
                   "resolved": "https://registry.npmjs.org/recast/-/recast-0.10.43.tgz",
                   "dependencies": {
                     "esprima-fb": {
                       "version": "15001.1001.0-dev-harmony-fb",
-                      "from": "esprima-fb@>=15001.1001.0-dev-harmony-fb <15001.1002.0",
+                      "from": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1001.0-dev-harmony-fb.tgz",
                       "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1001.0-dev-harmony-fb.tgz"
                     },
                     "source-map": {
                       "version": "0.5.3",
-                      "from": "source-map@>=0.5.0 <0.6.0",
+                      "from": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz",
                       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz"
                     },
                     "ast-types": {
                       "version": "0.8.15",
-                      "from": "ast-types@0.8.15",
+                      "from": "https://registry.npmjs.org/ast-types/-/ast-types-0.8.15.tgz",
                       "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.8.15.tgz"
                     }
                   }
@@ -4470,22 +4470,22 @@
             },
             "esprima-fb": {
               "version": "15001.1.0-dev-harmony-fb",
-              "from": "esprima-fb@>=15001.1.0-dev-harmony-fb <15002.0.0",
+              "from": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1.0-dev-harmony-fb.tgz",
               "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1.0-dev-harmony-fb.tgz"
             },
             "object-assign": {
               "version": "2.1.1",
-              "from": "object-assign@>=2.0.0 <3.0.0",
+              "from": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz",
               "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz"
             },
             "source-map": {
               "version": "0.4.4",
-              "from": "source-map@>=0.4.2 <0.5.0",
+              "from": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
               "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
               "dependencies": {
                 "amdefine": {
                   "version": "1.0.0",
-                  "from": "amdefine@>=0.0.4",
+                  "from": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
                 }
               }
@@ -4494,17 +4494,17 @@
         },
         "loader-utils": {
           "version": "0.2.12",
-          "from": "loader-utils@>=0.2.7 <0.3.0",
+          "from": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.12.tgz",
           "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.12.tgz",
           "dependencies": {
             "big.js": {
               "version": "3.1.3",
-              "from": "big.js@>=3.0.2 <4.0.0",
+              "from": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz",
               "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz"
             },
             "json5": {
               "version": "0.4.0",
-              "from": "json5@>=0.4.0 <0.5.0",
+              "from": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz",
               "resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz"
             }
           }
@@ -4513,118 +4513,113 @@
     },
     "lodash": {
       "version": "3.10.1",
-      "from": "lodash@>=3.10.1 <4.0.0",
+      "from": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
     },
     "material-ui": {
       "version": "0.14.3",
-      "from": "material-ui@>=0.14.2 <0.15.0",
+      "from": "https://registry.npmjs.org/material-ui/-/material-ui-0.14.3.tgz",
       "resolved": "https://registry.npmjs.org/material-ui/-/material-ui-0.14.3.tgz",
       "dependencies": {
         "inline-style-prefixer": {
           "version": "0.6.7",
-          "from": "inline-style-prefixer@>=0.6.6 <0.7.0",
+          "from": "https://registry.npmjs.org/inline-style-prefixer/-/inline-style-prefixer-0.6.7.tgz",
           "resolved": "https://registry.npmjs.org/inline-style-prefixer/-/inline-style-prefixer-0.6.7.tgz",
           "dependencies": {
             "bowser": {
               "version": "1.0.0",
-              "from": "bowser@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/bowser/-/bowser-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/bowser/-/bowser-1.0.0.tgz"
             }
           }
         },
-        "lodash.flowright": {
-          "version": "3.2.1",
-          "from": "lodash.flowright@>=3.2.1 <4.0.0",
-          "resolved": "https://registry.npmjs.org/lodash.flowright/-/lodash.flowright-3.2.1.tgz"
-        },
         "lodash.merge": {
           "version": "3.3.2",
-          "from": "lodash.merge@>=3.3.2 <4.0.0",
+          "from": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-3.3.2.tgz",
           "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-3.3.2.tgz",
           "dependencies": {
             "lodash._arraycopy": {
               "version": "3.0.0",
-              "from": "lodash._arraycopy@>=3.0.0 <4.0.0",
+              "from": "https://registry.npmjs.org/lodash._arraycopy/-/lodash._arraycopy-3.0.0.tgz",
               "resolved": "https://registry.npmjs.org/lodash._arraycopy/-/lodash._arraycopy-3.0.0.tgz"
             },
             "lodash._arrayeach": {
               "version": "3.0.0",
-              "from": "lodash._arrayeach@>=3.0.0 <4.0.0",
+              "from": "https://registry.npmjs.org/lodash._arrayeach/-/lodash._arrayeach-3.0.0.tgz",
               "resolved": "https://registry.npmjs.org/lodash._arrayeach/-/lodash._arrayeach-3.0.0.tgz"
             },
             "lodash._createassigner": {
               "version": "3.1.1",
-              "from": "lodash._createassigner@>=3.0.0 <4.0.0",
+              "from": "https://registry.npmjs.org/lodash._createassigner/-/lodash._createassigner-3.1.1.tgz",
               "resolved": "https://registry.npmjs.org/lodash._createassigner/-/lodash._createassigner-3.1.1.tgz",
               "dependencies": {
                 "lodash._bindcallback": {
                   "version": "3.0.1",
-                  "from": "lodash._bindcallback@>=3.0.0 <4.0.0",
+                  "from": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz"
                 },
                 "lodash._isiterateecall": {
                   "version": "3.0.9",
-                  "from": "lodash._isiterateecall@>=3.0.0 <4.0.0",
+                  "from": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
                   "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz"
                 },
                 "lodash.restparam": {
                   "version": "3.6.1",
-                  "from": "lodash.restparam@>=3.0.0 <4.0.0",
+                  "from": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
                   "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz"
                 }
               }
             },
             "lodash._getnative": {
               "version": "3.9.1",
-              "from": "lodash._getnative@>=3.0.0 <4.0.0",
+              "from": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
               "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz"
             },
             "lodash.isarguments": {
               "version": "3.0.6",
-              "from": "lodash.isarguments@>=3.0.0 <4.0.0",
+              "from": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.6.tgz",
               "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.6.tgz"
             },
             "lodash.isarray": {
               "version": "3.0.4",
-              "from": "lodash.isarray@>=3.0.0 <4.0.0",
+              "from": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
               "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
             },
             "lodash.isplainobject": {
               "version": "3.2.0",
-              "from": "lodash.isplainobject@>=3.0.0 <4.0.0",
+              "from": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-3.2.0.tgz",
               "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-3.2.0.tgz",
               "dependencies": {
                 "lodash._basefor": {
                   "version": "3.0.3",
-                  "from": "lodash._basefor@>=3.0.0 <4.0.0",
+                  "from": "https://registry.npmjs.org/lodash._basefor/-/lodash._basefor-3.0.3.tgz",
                   "resolved": "https://registry.npmjs.org/lodash._basefor/-/lodash._basefor-3.0.3.tgz"
                 }
               }
             },
             "lodash.istypedarray": {
               "version": "3.0.4",
-              "from": "lodash.istypedarray@>=3.0.0 <4.0.0",
+              "from": "https://registry.npmjs.org/lodash.istypedarray/-/lodash.istypedarray-3.0.4.tgz",
               "resolved": "https://registry.npmjs.org/lodash.istypedarray/-/lodash.istypedarray-3.0.4.tgz"
             },
             "lodash.keys": {
               "version": "3.1.2",
-              "from": "lodash.keys@>=3.0.0 <4.0.0",
+              "from": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
               "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz"
             },
             "lodash.keysin": {
               "version": "3.0.8",
-              "from": "lodash.keysin@>=3.0.0 <4.0.0",
+              "from": "https://registry.npmjs.org/lodash.keysin/-/lodash.keysin-3.0.8.tgz",
               "resolved": "https://registry.npmjs.org/lodash.keysin/-/lodash.keysin-3.0.8.tgz"
             },
             "lodash.toplainobject": {
               "version": "3.0.0",
-              "from": "lodash.toplainobject@>=3.0.0 <4.0.0",
+              "from": "https://registry.npmjs.org/lodash.toplainobject/-/lodash.toplainobject-3.0.0.tgz",
               "resolved": "https://registry.npmjs.org/lodash.toplainobject/-/lodash.toplainobject-3.0.0.tgz",
               "dependencies": {
                 "lodash._basecopy": {
                   "version": "3.0.1",
-                  "from": "lodash._basecopy@>=3.0.0 <4.0.0",
+                  "from": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz"
                 }
               }
@@ -4633,17 +4628,17 @@
         },
         "lodash.throttle": {
           "version": "3.0.4",
-          "from": "lodash.throttle@>=3.0.4 <3.1.0",
+          "from": "https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-3.0.4.tgz",
           "resolved": "https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-3.0.4.tgz",
           "dependencies": {
             "lodash.debounce": {
               "version": "3.1.1",
-              "from": "lodash.debounce@>=3.0.0 <4.0.0",
+              "from": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-3.1.1.tgz",
               "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-3.1.1.tgz",
               "dependencies": {
                 "lodash._getnative": {
                   "version": "3.9.1",
-                  "from": "lodash._getnative@>=3.0.0 <4.0.0",
+                  "from": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
                   "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz"
                 }
               }
@@ -4652,37 +4647,37 @@
         },
         "react-addons-create-fragment": {
           "version": "0.14.7",
-          "from": "react-addons-create-fragment@>=0.14.0 <0.15.0",
+          "from": "https://registry.npmjs.org/react-addons-create-fragment/-/react-addons-create-fragment-0.14.7.tgz",
           "resolved": "https://registry.npmjs.org/react-addons-create-fragment/-/react-addons-create-fragment-0.14.7.tgz"
         },
         "react-addons-pure-render-mixin": {
           "version": "0.14.7",
-          "from": "react-addons-pure-render-mixin@>=0.14.0 <0.15.0",
+          "from": "https://registry.npmjs.org/react-addons-pure-render-mixin/-/react-addons-pure-render-mixin-0.14.7.tgz",
           "resolved": "https://registry.npmjs.org/react-addons-pure-render-mixin/-/react-addons-pure-render-mixin-0.14.7.tgz"
         },
         "react-addons-transition-group": {
           "version": "0.14.7",
-          "from": "react-addons-transition-group@>=0.14.0 <0.15.0",
+          "from": "https://registry.npmjs.org/react-addons-transition-group/-/react-addons-transition-group-0.14.7.tgz",
           "resolved": "https://registry.npmjs.org/react-addons-transition-group/-/react-addons-transition-group-0.14.7.tgz"
         },
         "react-addons-update": {
           "version": "0.14.7",
-          "from": "react-addons-update@>=0.14.0 <0.15.0",
+          "from": "https://registry.npmjs.org/react-addons-update/-/react-addons-update-0.14.7.tgz",
           "resolved": "https://registry.npmjs.org/react-addons-update/-/react-addons-update-0.14.7.tgz"
         },
         "warning": {
           "version": "2.1.0",
-          "from": "warning@>=2.1.0 <3.0.0",
+          "from": "https://registry.npmjs.org/warning/-/warning-2.1.0.tgz",
           "resolved": "https://registry.npmjs.org/warning/-/warning-2.1.0.tgz",
           "dependencies": {
             "loose-envify": {
               "version": "1.1.0",
-              "from": "loose-envify@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz",
               "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz",
               "dependencies": {
                 "js-tokens": {
                   "version": "1.0.2",
-                  "from": "js-tokens@>=1.0.1 <2.0.0",
+                  "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
                 }
               }
@@ -4693,17 +4688,17 @@
     },
     "node-neat": {
       "version": "1.7.2",
-      "from": "node-neat@>=1.7.2 <2.0.0",
+      "from": "https://registry.npmjs.org/node-neat/-/node-neat-1.7.2.tgz",
       "resolved": "https://registry.npmjs.org/node-neat/-/node-neat-1.7.2.tgz",
       "dependencies": {
         "node-bourbon": {
           "version": "4.2.3",
-          "from": "node-bourbon@>=4.2.3 <5.0.0",
+          "from": "https://registry.npmjs.org/node-bourbon/-/node-bourbon-4.2.3.tgz",
           "resolved": "https://registry.npmjs.org/node-bourbon/-/node-bourbon-4.2.3.tgz",
           "dependencies": {
             "bourbon": {
               "version": "4.2.3",
-              "from": "bourbon@4.2.3",
+              "from": "https://registry.npmjs.org/bourbon/-/bourbon-4.2.3.tgz",
               "resolved": "https://registry.npmjs.org/bourbon/-/bourbon-4.2.3.tgz"
             }
           }
@@ -4712,107 +4707,107 @@
     },
     "node-sass": {
       "version": "3.4.2",
-      "from": "node-sass@>=3.4.2 <4.0.0",
+      "from": "https://registry.npmjs.org/node-sass/-/node-sass-3.4.2.tgz",
       "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-3.4.2.tgz",
       "dependencies": {
         "async-foreach": {
           "version": "0.1.3",
-          "from": "async-foreach@>=0.1.3 <0.2.0",
+          "from": "https://registry.npmjs.org/async-foreach/-/async-foreach-0.1.3.tgz",
           "resolved": "https://registry.npmjs.org/async-foreach/-/async-foreach-0.1.3.tgz"
         },
         "chalk": {
           "version": "1.1.1",
-          "from": "chalk@>=1.1.1 <2.0.0",
+          "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
           "dependencies": {
             "ansi-styles": {
               "version": "2.1.0",
-              "from": "ansi-styles@>=2.1.0 <3.0.0",
+              "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz",
               "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
             },
             "escape-string-regexp": {
               "version": "1.0.4",
-              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+              "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz",
               "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz"
             },
             "has-ansi": {
               "version": "2.0.0",
-              "from": "has-ansi@>=2.0.0 <3.0.0",
+              "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
               "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "2.0.0",
-                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                 }
               }
             },
             "strip-ansi": {
               "version": "3.0.0",
-              "from": "strip-ansi@>=3.0.0 <4.0.0",
+              "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "2.0.0",
-                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                 }
               }
             },
             "supports-color": {
               "version": "2.0.0",
-              "from": "supports-color@>=2.0.0 <3.0.0",
+              "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
             }
           }
         },
         "cross-spawn": {
           "version": "2.1.5",
-          "from": "cross-spawn@>=2.0.0 <3.0.0",
+          "from": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-2.1.5.tgz",
           "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-2.1.5.tgz",
           "dependencies": {
             "cross-spawn-async": {
               "version": "2.1.8",
-              "from": "cross-spawn-async@>=2.0.0 <3.0.0",
+              "from": "https://registry.npmjs.org/cross-spawn-async/-/cross-spawn-async-2.1.8.tgz",
               "resolved": "https://registry.npmjs.org/cross-spawn-async/-/cross-spawn-async-2.1.8.tgz",
               "dependencies": {
                 "lru-cache": {
                   "version": "4.0.0",
-                  "from": "lru-cache@>=4.0.0 <5.0.0",
+                  "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.0.0.tgz",
                   "dependencies": {
                     "pseudomap": {
                       "version": "1.0.2",
-                      "from": "pseudomap@>=1.0.1 <2.0.0",
+                      "from": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
                       "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz"
                     },
                     "yallist": {
                       "version": "2.0.0",
-                      "from": "yallist@>=2.0.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/yallist/-/yallist-2.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.0.0.tgz"
                     }
                   }
                 },
                 "which": {
                   "version": "1.2.4",
-                  "from": "which@>=1.2.4 <2.0.0",
+                  "from": "https://registry.npmjs.org/which/-/which-1.2.4.tgz",
                   "resolved": "https://registry.npmjs.org/which/-/which-1.2.4.tgz",
                   "dependencies": {
                     "is-absolute": {
                       "version": "0.1.7",
-                      "from": "is-absolute@>=0.1.7 <0.2.0",
+                      "from": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.1.7.tgz",
                       "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.1.7.tgz",
                       "dependencies": {
                         "is-relative": {
                           "version": "0.1.3",
-                          "from": "is-relative@>=0.1.0 <0.2.0",
+                          "from": "https://registry.npmjs.org/is-relative/-/is-relative-0.1.3.tgz",
                           "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-0.1.3.tgz"
                         }
                       }
                     },
                     "isexe": {
                       "version": "1.1.1",
-                      "from": "isexe@>=1.1.1 <2.0.0",
+                      "from": "https://registry.npmjs.org/isexe/-/isexe-1.1.1.tgz",
                       "resolved": "https://registry.npmjs.org/isexe/-/isexe-1.1.1.tgz"
                     }
                   }
@@ -4821,52 +4816,52 @@
             },
             "spawn-sync": {
               "version": "1.0.15",
-              "from": "spawn-sync@>=1.0.15 <2.0.0",
+              "from": "https://registry.npmjs.org/spawn-sync/-/spawn-sync-1.0.15.tgz",
               "resolved": "https://registry.npmjs.org/spawn-sync/-/spawn-sync-1.0.15.tgz",
               "dependencies": {
                 "concat-stream": {
                   "version": "1.5.1",
-                  "from": "concat-stream@>=1.4.7 <2.0.0",
+                  "from": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.1.tgz",
                   "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.1.tgz",
                   "dependencies": {
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@>=2.0.1 <2.1.0",
+                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     },
                     "typedarray": {
                       "version": "0.0.6",
-                      "from": "typedarray@>=0.0.5 <0.1.0",
+                      "from": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
                       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
                     },
                     "readable-stream": {
                       "version": "2.0.5",
-                      "from": "readable-stream@>=2.0.0 <2.1.0",
+                      "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
                       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
                       "dependencies": {
                         "core-util-is": {
                           "version": "1.0.2",
-                          "from": "core-util-is@>=1.0.0 <1.1.0",
+                          "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
                           "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                         },
                         "isarray": {
                           "version": "0.0.1",
-                          "from": "isarray@0.0.1",
+                          "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                         },
                         "process-nextick-args": {
                           "version": "1.0.6",
-                          "from": "process-nextick-args@>=1.0.6 <1.1.0",
+                          "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz",
                           "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
                         },
                         "string_decoder": {
                           "version": "0.10.31",
-                          "from": "string_decoder@>=0.10.0 <0.11.0",
+                          "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                         },
                         "util-deprecate": {
                           "version": "1.0.2",
-                          "from": "util-deprecate@>=1.0.1 <1.1.0",
+                          "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
                           "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
                         }
                       }
@@ -4875,7 +4870,7 @@
                 },
                 "os-shim": {
                   "version": "0.1.3",
-                  "from": "os-shim@>=0.1.2 <0.2.0",
+                  "from": "https://registry.npmjs.org/os-shim/-/os-shim-0.1.3.tgz",
                   "resolved": "https://registry.npmjs.org/os-shim/-/os-shim-0.1.3.tgz"
                 }
               }
@@ -4884,49 +4879,49 @@
         },
         "gaze": {
           "version": "0.5.2",
-          "from": "gaze@>=0.5.1 <0.6.0",
+          "from": "https://registry.npmjs.org/gaze/-/gaze-0.5.2.tgz",
           "resolved": "https://registry.npmjs.org/gaze/-/gaze-0.5.2.tgz",
           "dependencies": {
             "globule": {
               "version": "0.1.0",
-              "from": "globule@>=0.1.0 <0.2.0",
+              "from": "https://registry.npmjs.org/globule/-/globule-0.1.0.tgz",
               "resolved": "https://registry.npmjs.org/globule/-/globule-0.1.0.tgz",
               "dependencies": {
                 "lodash": {
                   "version": "1.0.2",
-                  "from": "lodash@>=1.0.1 <1.1.0",
+                  "from": "https://registry.npmjs.org/lodash/-/lodash-1.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/lodash/-/lodash-1.0.2.tgz"
                 },
                 "glob": {
                   "version": "3.1.21",
-                  "from": "glob@>=3.1.21 <3.2.0",
+                  "from": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
                   "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
                   "dependencies": {
                     "graceful-fs": {
                       "version": "1.2.3",
-                      "from": "graceful-fs@>=1.2.0 <1.3.0",
+                      "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz",
                       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
                     },
                     "inherits": {
                       "version": "1.0.2",
-                      "from": "inherits@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/inherits/-/inherits-1.0.2.tgz",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.2.tgz"
                     }
                   }
                 },
                 "minimatch": {
                   "version": "0.2.14",
-                  "from": "minimatch@>=0.2.11 <0.3.0",
+                  "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
                   "dependencies": {
                     "lru-cache": {
                       "version": "2.7.3",
-                      "from": "lru-cache@>=2.0.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
                       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz"
                     },
                     "sigmund": {
                       "version": "1.0.1",
-                      "from": "sigmund@>=1.0.0 <1.1.0",
+                      "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
                     }
                   }
@@ -4937,49 +4932,49 @@
         },
         "get-stdin": {
           "version": "4.0.1",
-          "from": "get-stdin@>=4.0.1 <5.0.0",
+          "from": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
           "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
         },
         "glob": {
           "version": "5.0.15",
-          "from": "glob@>=5.0.14 <6.0.0",
+          "from": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
           "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
           "dependencies": {
             "inflight": {
               "version": "1.0.4",
-              "from": "inflight@>=1.0.4 <2.0.0",
+              "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
               "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
               "dependencies": {
                 "wrappy": {
                   "version": "1.0.1",
-                  "from": "wrappy@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                 }
               }
             },
             "inherits": {
               "version": "2.0.1",
-              "from": "inherits@>=2.0.0 <3.0.0",
+              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             },
             "minimatch": {
               "version": "3.0.0",
-              "from": "minimatch@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0",
+              "from": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
               "dependencies": {
                 "brace-expansion": {
                   "version": "1.1.2",
-                  "from": "brace-expansion@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.2.tgz",
                   "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.2.tgz",
                   "dependencies": {
                     "balanced-match": {
                       "version": "0.3.0",
-                      "from": "balanced-match@>=0.3.0 <0.4.0",
+                      "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz",
                       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
                     },
                     "concat-map": {
                       "version": "0.0.1",
-                      "from": "concat-map@0.0.1",
+                      "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                     }
                   }
@@ -4988,136 +4983,136 @@
             },
             "once": {
               "version": "1.3.3",
-              "from": "once@>=1.3.0 <2.0.0",
+              "from": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
               "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
               "dependencies": {
                 "wrappy": {
                   "version": "1.0.1",
-                  "from": "wrappy@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                 }
               }
             },
             "path-is-absolute": {
               "version": "1.0.0",
-              "from": "path-is-absolute@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
             }
           }
         },
         "meow": {
           "version": "3.7.0",
-          "from": "meow@>=3.3.0 <4.0.0",
+          "from": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
           "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
           "dependencies": {
             "camelcase-keys": {
               "version": "2.0.0",
-              "from": "camelcase-keys@>=2.0.0 <3.0.0",
+              "from": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.0.0.tgz",
               "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.0.0.tgz",
               "dependencies": {
                 "camelcase": {
                   "version": "2.1.0",
-                  "from": "camelcase@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.0.tgz"
                 }
               }
             },
             "decamelize": {
               "version": "1.1.2",
-              "from": "decamelize@>=1.1.2 <2.0.0",
+              "from": "https://registry.npmjs.org/decamelize/-/decamelize-1.1.2.tgz",
               "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.1.2.tgz",
               "dependencies": {
                 "escape-string-regexp": {
                   "version": "1.0.4",
-                  "from": "escape-string-regexp@>=1.0.4 <2.0.0",
+                  "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz",
                   "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz"
                 }
               }
             },
             "loud-rejection": {
               "version": "1.2.1",
-              "from": "loud-rejection@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.2.1.tgz",
               "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.2.1.tgz",
               "dependencies": {
                 "array-find-index": {
                   "version": "1.0.1",
-                  "from": "array-find-index@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.1.tgz"
                 },
                 "signal-exit": {
                   "version": "2.1.2",
-                  "from": "signal-exit@>=2.1.2 <3.0.0",
+                  "from": "https://registry.npmjs.org/signal-exit/-/signal-exit-2.1.2.tgz",
                   "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-2.1.2.tgz"
                 }
               }
             },
             "map-obj": {
               "version": "1.0.1",
-              "from": "map-obj@>=1.0.1 <2.0.0",
+              "from": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
               "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
             },
             "minimist": {
               "version": "1.2.0",
-              "from": "minimist@>=1.1.3 <2.0.0",
+              "from": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
               "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
             },
             "normalize-package-data": {
               "version": "2.3.5",
-              "from": "normalize-package-data@>=2.3.4 <3.0.0",
+              "from": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz",
               "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz",
               "dependencies": {
                 "hosted-git-info": {
                   "version": "2.1.4",
-                  "from": "hosted-git-info@>=2.1.4 <3.0.0",
+                  "from": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.4.tgz",
                   "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.4.tgz"
                 },
                 "is-builtin-module": {
                   "version": "1.0.0",
-                  "from": "is-builtin-module@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
                   "dependencies": {
                     "builtin-modules": {
                       "version": "1.1.1",
-                      "from": "builtin-modules@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
                       "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz"
                     }
                   }
                 },
                 "semver": {
                   "version": "5.1.0",
-                  "from": "semver@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0||>=4.0.0 <5.0.0||>=5.0.0 <6.0.0",
+                  "from": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz"
                 },
                 "validate-npm-package-license": {
                   "version": "3.0.1",
-                  "from": "validate-npm-package-license@>=3.0.1 <4.0.0",
+                  "from": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
                   "dependencies": {
                     "spdx-correct": {
                       "version": "1.0.2",
-                      "from": "spdx-correct@>=1.0.0 <1.1.0",
+                      "from": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
                       "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
                       "dependencies": {
                         "spdx-license-ids": {
                           "version": "1.2.0",
-                          "from": "spdx-license-ids@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.0.tgz",
                           "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.0.tgz"
                         }
                       }
                     },
                     "spdx-expression-parse": {
                       "version": "1.0.2",
-                      "from": "spdx-expression-parse@>=1.0.0 <1.1.0",
+                      "from": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.2.tgz",
                       "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.2.tgz",
                       "dependencies": {
                         "spdx-exceptions": {
                           "version": "1.0.4",
-                          "from": "spdx-exceptions@>=1.0.4 <2.0.0",
+                          "from": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-1.0.4.tgz",
                           "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-1.0.4.tgz"
                         },
                         "spdx-license-ids": {
                           "version": "1.2.0",
-                          "from": "spdx-license-ids@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.0.tgz",
                           "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.0.tgz"
                         }
                       }
@@ -5128,32 +5123,32 @@
             },
             "object-assign": {
               "version": "4.0.1",
-              "from": "object-assign@>=4.0.1 <5.0.0",
+              "from": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz",
               "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz"
             },
             "read-pkg-up": {
               "version": "1.0.1",
-              "from": "read-pkg-up@>=1.0.1 <2.0.0",
+              "from": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
               "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
               "dependencies": {
                 "find-up": {
                   "version": "1.1.0",
-                  "from": "find-up@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/find-up/-/find-up-1.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.0.tgz",
                   "dependencies": {
                     "path-exists": {
                       "version": "2.1.0",
-                      "from": "path-exists@>=2.0.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
                       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz"
                     },
                     "pinkie-promise": {
                       "version": "2.0.0",
-                      "from": "pinkie-promise@>=2.0.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
                       "dependencies": {
                         "pinkie": {
                           "version": "2.0.4",
-                          "from": "pinkie@>=2.0.0 <3.0.0",
+                          "from": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
                           "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
                         }
                       }
@@ -5162,32 +5157,32 @@
                 },
                 "read-pkg": {
                   "version": "1.1.0",
-                  "from": "read-pkg@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
                   "dependencies": {
                     "load-json-file": {
                       "version": "1.1.0",
-                      "from": "load-json-file@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
                       "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
                       "dependencies": {
                         "graceful-fs": {
                           "version": "4.1.3",
-                          "from": "graceful-fs@>=4.1.2 <5.0.0",
+                          "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz",
                           "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz"
                         },
                         "parse-json": {
                           "version": "2.2.0",
-                          "from": "parse-json@>=2.2.0 <3.0.0",
+                          "from": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
                           "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
                           "dependencies": {
                             "error-ex": {
                               "version": "1.3.0",
-                              "from": "error-ex@>=1.2.0 <2.0.0",
+                              "from": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.0.tgz",
                               "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.0.tgz",
                               "dependencies": {
                                 "is-arrayish": {
                                   "version": "0.2.1",
-                                  "from": "is-arrayish@>=0.2.1 <0.3.0",
+                                  "from": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
                                   "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz"
                                 }
                               }
@@ -5196,29 +5191,29 @@
                         },
                         "pify": {
                           "version": "2.3.0",
-                          "from": "pify@>=2.0.0 <3.0.0",
+                          "from": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
                           "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
                         },
                         "pinkie-promise": {
                           "version": "2.0.0",
-                          "from": "pinkie-promise@>=2.0.0 <3.0.0",
+                          "from": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
                           "dependencies": {
                             "pinkie": {
                               "version": "2.0.4",
-                              "from": "pinkie@>=2.0.0 <3.0.0",
+                              "from": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
                               "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
                             }
                           }
                         },
                         "strip-bom": {
                           "version": "2.0.0",
-                          "from": "strip-bom@>=2.0.0 <3.0.0",
+                          "from": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
                           "dependencies": {
                             "is-utf8": {
                               "version": "0.2.1",
-                              "from": "is-utf8@>=0.2.0 <0.3.0",
+                              "from": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
                               "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz"
                             }
                           }
@@ -5227,27 +5222,27 @@
                     },
                     "path-type": {
                       "version": "1.1.0",
-                      "from": "path-type@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
                       "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
                       "dependencies": {
                         "graceful-fs": {
                           "version": "4.1.3",
-                          "from": "graceful-fs@>=4.1.2 <5.0.0",
+                          "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz",
                           "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz"
                         },
                         "pify": {
                           "version": "2.3.0",
-                          "from": "pify@>=2.0.0 <3.0.0",
+                          "from": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
                           "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
                         },
                         "pinkie-promise": {
                           "version": "2.0.0",
-                          "from": "pinkie-promise@>=2.0.0 <3.0.0",
+                          "from": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
                           "dependencies": {
                             "pinkie": {
                               "version": "2.0.4",
-                              "from": "pinkie@>=2.0.0 <3.0.0",
+                              "from": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
                               "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
                             }
                           }
@@ -5260,27 +5255,27 @@
             },
             "redent": {
               "version": "1.0.0",
-              "from": "redent@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
               "dependencies": {
                 "indent-string": {
                   "version": "2.1.0",
-                  "from": "indent-string@>=2.1.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
                   "dependencies": {
                     "repeating": {
                       "version": "2.0.0",
-                      "from": "repeating@>=2.0.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/repeating/-/repeating-2.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.0.tgz",
                       "dependencies": {
                         "is-finite": {
                           "version": "1.0.1",
-                          "from": "is-finite@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
                           "dependencies": {
                             "number-is-nan": {
                               "version": "1.0.0",
-                              "from": "number-is-nan@>=1.0.0 <2.0.0",
+                              "from": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
                             }
                           }
@@ -5291,172 +5286,172 @@
                 },
                 "strip-indent": {
                   "version": "1.0.1",
-                  "from": "strip-indent@>=1.0.1 <2.0.0",
+                  "from": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz"
                 }
               }
             },
             "trim-newlines": {
               "version": "1.0.0",
-              "from": "trim-newlines@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz"
             }
           }
         },
         "mkdirp": {
           "version": "0.5.1",
-          "from": "mkdirp@>=0.5.1 <0.6.0",
+          "from": "mkdirp@>=0.5.0 <0.6.0",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "dependencies": {
             "minimist": {
               "version": "0.0.8",
-              "from": "minimist@0.0.8",
+              "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
               "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
             }
           }
         },
         "nan": {
           "version": "2.2.0",
-          "from": "nan@>=2.0.8 <3.0.0",
+          "from": "https://registry.npmjs.org/nan/-/nan-2.2.0.tgz",
           "resolved": "https://registry.npmjs.org/nan/-/nan-2.2.0.tgz"
         },
         "npmconf": {
           "version": "2.1.2",
-          "from": "npmconf@>=2.1.2 <3.0.0",
+          "from": "https://registry.npmjs.org/npmconf/-/npmconf-2.1.2.tgz",
           "resolved": "https://registry.npmjs.org/npmconf/-/npmconf-2.1.2.tgz",
           "dependencies": {
             "config-chain": {
               "version": "1.1.10",
-              "from": "config-chain@>=1.1.8 <1.2.0",
+              "from": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.10.tgz",
               "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.10.tgz",
               "dependencies": {
                 "proto-list": {
                   "version": "1.2.4",
-                  "from": "proto-list@>=1.2.1 <1.3.0",
+                  "from": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
                   "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz"
                 }
               }
             },
             "inherits": {
               "version": "2.0.1",
-              "from": "inherits@>=2.0.1 <2.1.0",
+              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             },
             "ini": {
               "version": "1.3.4",
-              "from": "ini@>=1.2.0 <2.0.0",
+              "from": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
               "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
             },
             "nopt": {
               "version": "3.0.6",
-              "from": "nopt@>=3.0.1 <3.1.0",
+              "from": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
               "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
               "dependencies": {
                 "abbrev": {
                   "version": "1.0.7",
-                  "from": "abbrev@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz",
                   "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
                 }
               }
             },
             "once": {
               "version": "1.3.3",
-              "from": "once@>=1.3.0 <1.4.0",
+              "from": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
               "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
               "dependencies": {
                 "wrappy": {
                   "version": "1.0.1",
-                  "from": "wrappy@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                 }
               }
             },
             "osenv": {
               "version": "0.1.3",
-              "from": "osenv@>=0.1.0 <0.2.0",
+              "from": "https://registry.npmjs.org/osenv/-/osenv-0.1.3.tgz",
               "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.3.tgz",
               "dependencies": {
                 "os-homedir": {
                   "version": "1.0.1",
-                  "from": "os-homedir@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz"
                 },
                 "os-tmpdir": {
                   "version": "1.0.1",
-                  "from": "os-tmpdir@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz"
                 }
               }
             },
             "semver": {
               "version": "4.3.6",
-              "from": "semver@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0||>=4.0.0 <5.0.0",
+              "from": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
               "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz"
             },
             "uid-number": {
               "version": "0.0.5",
-              "from": "uid-number@0.0.5",
+              "from": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.5.tgz",
               "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.5.tgz"
             }
           }
         },
         "node-gyp": {
           "version": "3.2.1",
-          "from": "node-gyp@>=3.0.1 <4.0.0",
+          "from": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.2.1.tgz",
           "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.2.1.tgz",
           "dependencies": {
             "fstream": {
               "version": "1.0.8",
-              "from": "fstream@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/fstream/-/fstream-1.0.8.tgz",
               "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.8.tgz",
               "dependencies": {
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@>=2.0.0 <2.1.0",
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 }
               }
             },
             "glob": {
               "version": "4.5.3",
-              "from": "glob@>=3.0.0 <4.0.0||>=4.0.0 <5.0.0",
+              "from": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
               "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
               "dependencies": {
                 "inflight": {
                   "version": "1.0.4",
-                  "from": "inflight@>=1.0.4 <2.0.0",
+                  "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
                   "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
                   "dependencies": {
                     "wrappy": {
                       "version": "1.0.1",
-                      "from": "wrappy@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                     }
                   }
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "minimatch": {
                   "version": "2.0.10",
-                  "from": "minimatch@>=2.0.1 <3.0.0",
+                  "from": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
                   "dependencies": {
                     "brace-expansion": {
                       "version": "1.1.2",
-                      "from": "brace-expansion@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.2.tgz",
                       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.2.tgz",
                       "dependencies": {
                         "balanced-match": {
                           "version": "0.3.0",
-                          "from": "balanced-match@>=0.3.0 <0.4.0",
+                          "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz",
                           "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
                         },
                         "concat-map": {
                           "version": "0.0.1",
-                          "from": "concat-map@0.0.1",
+                          "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                         }
                       }
@@ -5465,12 +5460,12 @@
                 },
                 "once": {
                   "version": "1.3.3",
-                  "from": "once@>=1.3.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
                   "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
                   "dependencies": {
                     "wrappy": {
                       "version": "1.0.1",
-                      "from": "wrappy@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                     }
                   }
@@ -5479,91 +5474,91 @@
             },
             "graceful-fs": {
               "version": "4.1.3",
-              "from": "graceful-fs@>=4.1.2 <5.0.0",
+              "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz",
               "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz"
             },
             "minimatch": {
               "version": "1.0.0",
-              "from": "minimatch@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/minimatch/-/minimatch-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-1.0.0.tgz",
               "dependencies": {
                 "lru-cache": {
                   "version": "2.7.3",
-                  "from": "lru-cache@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
                   "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz"
                 },
                 "sigmund": {
                   "version": "1.0.1",
-                  "from": "sigmund@>=1.0.0 <1.1.0",
+                  "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
                 }
               }
             },
             "nopt": {
               "version": "3.0.6",
-              "from": "nopt@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0",
+              "from": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
               "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
               "dependencies": {
                 "abbrev": {
                   "version": "1.0.7",
-                  "from": "abbrev@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz",
                   "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
                 }
               }
             },
             "npmlog": {
               "version": "1.2.1",
-              "from": "npmlog@>=0.0.0 <1.0.0||>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/npmlog/-/npmlog-1.2.1.tgz",
               "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-1.2.1.tgz",
               "dependencies": {
                 "ansi": {
                   "version": "0.3.1",
-                  "from": "ansi@>=0.3.0 <0.4.0",
+                  "from": "https://registry.npmjs.org/ansi/-/ansi-0.3.1.tgz",
                   "resolved": "https://registry.npmjs.org/ansi/-/ansi-0.3.1.tgz"
                 },
                 "are-we-there-yet": {
                   "version": "1.0.6",
-                  "from": "are-we-there-yet@>=1.0.0 <1.1.0",
+                  "from": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.0.6.tgz",
                   "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.0.6.tgz",
                   "dependencies": {
                     "delegates": {
                       "version": "1.0.0",
-                      "from": "delegates@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz"
                     },
                     "readable-stream": {
                       "version": "2.0.5",
-                      "from": "readable-stream@>=2.0.0 <3.0.0||>=1.1.13 <2.0.0",
+                      "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
                       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
                       "dependencies": {
                         "core-util-is": {
                           "version": "1.0.2",
-                          "from": "core-util-is@>=1.0.0 <1.1.0",
+                          "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
                           "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                         },
                         "inherits": {
                           "version": "2.0.1",
-                          "from": "inherits@>=2.0.1 <2.1.0",
+                          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                         },
                         "isarray": {
                           "version": "0.0.1",
-                          "from": "isarray@0.0.1",
+                          "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                         },
                         "process-nextick-args": {
                           "version": "1.0.6",
-                          "from": "process-nextick-args@>=1.0.6 <1.1.0",
+                          "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz",
                           "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
                         },
                         "string_decoder": {
                           "version": "0.10.31",
-                          "from": "string_decoder@>=0.10.0 <0.11.0",
+                          "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                         },
                         "util-deprecate": {
                           "version": "1.0.2",
-                          "from": "util-deprecate@>=1.0.1 <1.1.0",
+                          "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
                           "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
                         }
                       }
@@ -5572,44 +5567,44 @@
                 },
                 "gauge": {
                   "version": "1.2.5",
-                  "from": "gauge@>=1.2.0 <1.3.0",
+                  "from": "https://registry.npmjs.org/gauge/-/gauge-1.2.5.tgz",
                   "resolved": "https://registry.npmjs.org/gauge/-/gauge-1.2.5.tgz",
                   "dependencies": {
                     "has-unicode": {
                       "version": "2.0.0",
-                      "from": "has-unicode@>=2.0.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.0.tgz"
                     },
                     "lodash.pad": {
                       "version": "3.2.2",
-                      "from": "lodash.pad@>=3.0.0 <4.0.0",
+                      "from": "https://registry.npmjs.org/lodash.pad/-/lodash.pad-3.2.2.tgz",
                       "resolved": "https://registry.npmjs.org/lodash.pad/-/lodash.pad-3.2.2.tgz",
                       "dependencies": {
                         "lodash.repeat": {
                           "version": "3.1.2",
-                          "from": "lodash.repeat@>=3.0.0 <4.0.0",
+                          "from": "https://registry.npmjs.org/lodash.repeat/-/lodash.repeat-3.1.2.tgz",
                           "resolved": "https://registry.npmjs.org/lodash.repeat/-/lodash.repeat-3.1.2.tgz"
                         }
                       }
                     },
                     "lodash.padleft": {
                       "version": "3.1.1",
-                      "from": "lodash.padleft@>=3.0.0 <4.0.0",
+                      "from": "https://registry.npmjs.org/lodash.padleft/-/lodash.padleft-3.1.1.tgz",
                       "resolved": "https://registry.npmjs.org/lodash.padleft/-/lodash.padleft-3.1.1.tgz",
                       "dependencies": {
                         "lodash._basetostring": {
                           "version": "3.0.1",
-                          "from": "lodash._basetostring@>=3.0.0 <4.0.0",
+                          "from": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz"
                         },
                         "lodash._createpadding": {
                           "version": "3.6.1",
-                          "from": "lodash._createpadding@>=3.0.0 <4.0.0",
+                          "from": "https://registry.npmjs.org/lodash._createpadding/-/lodash._createpadding-3.6.1.tgz",
                           "resolved": "https://registry.npmjs.org/lodash._createpadding/-/lodash._createpadding-3.6.1.tgz",
                           "dependencies": {
                             "lodash.repeat": {
                               "version": "3.1.2",
-                              "from": "lodash.repeat@>=3.0.0 <4.0.0",
+                              "from": "https://registry.npmjs.org/lodash.repeat/-/lodash.repeat-3.1.2.tgz",
                               "resolved": "https://registry.npmjs.org/lodash.repeat/-/lodash.repeat-3.1.2.tgz"
                             }
                           }
@@ -5618,22 +5613,22 @@
                     },
                     "lodash.padright": {
                       "version": "3.1.1",
-                      "from": "lodash.padright@>=3.0.0 <4.0.0",
+                      "from": "https://registry.npmjs.org/lodash.padright/-/lodash.padright-3.1.1.tgz",
                       "resolved": "https://registry.npmjs.org/lodash.padright/-/lodash.padright-3.1.1.tgz",
                       "dependencies": {
                         "lodash._basetostring": {
                           "version": "3.0.1",
-                          "from": "lodash._basetostring@>=3.0.0 <4.0.0",
+                          "from": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz"
                         },
                         "lodash._createpadding": {
                           "version": "3.6.1",
-                          "from": "lodash._createpadding@>=3.0.0 <4.0.0",
+                          "from": "https://registry.npmjs.org/lodash._createpadding/-/lodash._createpadding-3.6.1.tgz",
                           "resolved": "https://registry.npmjs.org/lodash._createpadding/-/lodash._createpadding-3.6.1.tgz",
                           "dependencies": {
                             "lodash.repeat": {
                               "version": "3.1.2",
-                              "from": "lodash.repeat@>=3.0.0 <4.0.0",
+                              "from": "https://registry.npmjs.org/lodash.repeat/-/lodash.repeat-3.1.2.tgz",
                               "resolved": "https://registry.npmjs.org/lodash.repeat/-/lodash.repeat-3.1.2.tgz"
                             }
                           }
@@ -5646,61 +5641,61 @@
             },
             "osenv": {
               "version": "0.1.3",
-              "from": "osenv@>=0.0.0 <1.0.0",
+              "from": "https://registry.npmjs.org/osenv/-/osenv-0.1.3.tgz",
               "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.3.tgz",
               "dependencies": {
                 "os-homedir": {
                   "version": "1.0.1",
-                  "from": "os-homedir@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz"
                 },
                 "os-tmpdir": {
                   "version": "1.0.1",
-                  "from": "os-tmpdir@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz"
                 }
               }
             },
             "path-array": {
               "version": "1.0.1",
-              "from": "path-array@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/path-array/-/path-array-1.0.1.tgz",
               "resolved": "https://registry.npmjs.org/path-array/-/path-array-1.0.1.tgz",
               "dependencies": {
                 "array-index": {
                   "version": "1.0.0",
-                  "from": "array-index@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/array-index/-/array-index-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/array-index/-/array-index-1.0.0.tgz",
                   "dependencies": {
                     "debug": {
                       "version": "2.2.0",
-                      "from": "debug@>=2.2.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
                       "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
                       "dependencies": {
                         "ms": {
                           "version": "0.7.1",
-                          "from": "ms@0.7.1",
+                          "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
                           "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
                         }
                       }
                     },
                     "es6-symbol": {
                       "version": "3.0.2",
-                      "from": "es6-symbol@>=3.0.2 <4.0.0",
+                      "from": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.0.2.tgz",
                       "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.0.2.tgz",
                       "dependencies": {
                         "d": {
                           "version": "0.1.1",
-                          "from": "d@>=0.1.1 <0.2.0",
+                          "from": "https://registry.npmjs.org/d/-/d-0.1.1.tgz",
                           "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz"
                         },
                         "es5-ext": {
                           "version": "0.10.11",
-                          "from": "es5-ext@>=0.10.10 <0.11.0",
+                          "from": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.11.tgz",
                           "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.11.tgz",
                           "dependencies": {
                             "es6-iterator": {
                               "version": "2.0.0",
-                              "from": "es6-iterator@>=2.0.0 <3.0.0",
+                              "from": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.0.tgz"
                             }
                           }
@@ -5713,49 +5708,49 @@
             },
             "rimraf": {
               "version": "2.5.1",
-              "from": "rimraf@>=2.0.0 <3.0.0",
+              "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.1.tgz",
               "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.1.tgz",
               "dependencies": {
                 "glob": {
                   "version": "6.0.4",
-                  "from": "glob@>=6.0.1 <7.0.0",
+                  "from": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
                   "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
                   "dependencies": {
                     "inflight": {
                       "version": "1.0.4",
-                      "from": "inflight@>=1.0.4 <2.0.0",
+                      "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
                       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
                       "dependencies": {
                         "wrappy": {
                           "version": "1.0.1",
-                          "from": "wrappy@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                         }
                       }
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@>=2.0.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     },
                     "minimatch": {
                       "version": "3.0.0",
-                      "from": "minimatch@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0",
+                      "from": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
                       "dependencies": {
                         "brace-expansion": {
                           "version": "1.1.2",
-                          "from": "brace-expansion@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.2.tgz",
                           "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.2.tgz",
                           "dependencies": {
                             "balanced-match": {
                               "version": "0.3.0",
-                              "from": "balanced-match@>=0.3.0 <0.4.0",
+                              "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz",
                               "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
                             },
                             "concat-map": {
                               "version": "0.0.1",
-                              "from": "concat-map@0.0.1",
+                              "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
                               "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                             }
                           }
@@ -5764,19 +5759,19 @@
                     },
                     "once": {
                       "version": "1.3.3",
-                      "from": "once@>=1.3.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
                       "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
                       "dependencies": {
                         "wrappy": {
                           "version": "1.0.1",
-                          "from": "wrappy@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                         }
                       }
                     },
                     "path-is-absolute": {
                       "version": "1.0.0",
-                      "from": "path-is-absolute@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
                     }
                   }
@@ -5785,46 +5780,46 @@
             },
             "semver": {
               "version": "5.1.0",
-              "from": "semver@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0||>=4.0.0 <5.0.0||>=5.0.0 <6.0.0",
+              "from": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz",
               "resolved": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz"
             },
             "tar": {
               "version": "2.2.1",
-              "from": "tar@>=2.0.0 <3.0.0",
+              "from": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
               "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
               "dependencies": {
                 "block-stream": {
                   "version": "0.0.8",
-                  "from": "block-stream@*",
+                  "from": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.8.tgz",
                   "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.8.tgz"
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 }
               }
             },
             "which": {
               "version": "1.2.4",
-              "from": "which@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/which/-/which-1.2.4.tgz",
               "resolved": "https://registry.npmjs.org/which/-/which-1.2.4.tgz",
               "dependencies": {
                 "is-absolute": {
                   "version": "0.1.7",
-                  "from": "is-absolute@>=0.1.7 <0.2.0",
+                  "from": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.1.7.tgz",
                   "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.1.7.tgz",
                   "dependencies": {
                     "is-relative": {
                       "version": "0.1.3",
-                      "from": "is-relative@>=0.1.0 <0.2.0",
+                      "from": "https://registry.npmjs.org/is-relative/-/is-relative-0.1.3.tgz",
                       "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-0.1.3.tgz"
                     }
                   }
                 },
                 "isexe": {
                   "version": "1.1.1",
-                  "from": "isexe@>=1.1.1 <2.0.0",
+                  "from": "https://registry.npmjs.org/isexe/-/isexe-1.1.1.tgz",
                   "resolved": "https://registry.npmjs.org/isexe/-/isexe-1.1.1.tgz"
                 }
               }
@@ -5833,64 +5828,64 @@
         },
         "request": {
           "version": "2.69.0",
-          "from": "request@>=2.61.0 <3.0.0",
+          "from": "https://registry.npmjs.org/request/-/request-2.69.0.tgz",
           "resolved": "https://registry.npmjs.org/request/-/request-2.69.0.tgz",
           "dependencies": {
             "aws-sign2": {
               "version": "0.6.0",
-              "from": "aws-sign2@>=0.6.0 <0.7.0",
+              "from": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
               "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz"
             },
             "aws4": {
               "version": "1.2.1",
-              "from": "aws4@>=1.2.1 <2.0.0",
+              "from": "https://registry.npmjs.org/aws4/-/aws4-1.2.1.tgz",
               "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.2.1.tgz",
               "dependencies": {
                 "lru-cache": {
                   "version": "2.7.3",
-                  "from": "lru-cache@>=2.6.5 <3.0.0",
+                  "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
                   "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz"
                 }
               }
             },
             "bl": {
               "version": "1.0.2",
-              "from": "bl@>=1.0.0 <1.1.0",
+              "from": "https://registry.npmjs.org/bl/-/bl-1.0.2.tgz",
               "resolved": "https://registry.npmjs.org/bl/-/bl-1.0.2.tgz",
               "dependencies": {
                 "readable-stream": {
                   "version": "2.0.5",
-                  "from": "readable-stream@>=2.0.5 <2.1.0",
+                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.2",
-                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@>=2.0.1 <2.1.0",
+                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     },
                     "isarray": {
                       "version": "0.0.1",
-                      "from": "isarray@0.0.1",
+                      "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                     },
                     "process-nextick-args": {
                       "version": "1.0.6",
-                      "from": "process-nextick-args@>=1.0.6 <1.1.0",
+                      "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz",
                       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
                     },
                     "string_decoder": {
                       "version": "0.10.31",
-                      "from": "string_decoder@>=0.10.0 <0.11.0",
+                      "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                     },
                     "util-deprecate": {
                       "version": "1.0.2",
-                      "from": "util-deprecate@>=1.0.1 <1.1.0",
+                      "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
                       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
                     }
                   }
@@ -5899,102 +5894,102 @@
             },
             "caseless": {
               "version": "0.11.0",
-              "from": "caseless@>=0.11.0 <0.12.0",
+              "from": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
               "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz"
             },
             "combined-stream": {
               "version": "1.0.5",
-              "from": "combined-stream@>=1.0.5 <1.1.0",
+              "from": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
               "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
               "dependencies": {
                 "delayed-stream": {
                   "version": "1.0.0",
-                  "from": "delayed-stream@>=1.0.0 <1.1.0",
+                  "from": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
                 }
               }
             },
             "extend": {
               "version": "3.0.0",
-              "from": "extend@>=3.0.0 <3.1.0",
+              "from": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz",
               "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
             },
             "forever-agent": {
               "version": "0.6.1",
-              "from": "forever-agent@>=0.6.1 <0.7.0",
+              "from": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
               "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
             },
             "form-data": {
               "version": "1.0.0-rc3",
-              "from": "form-data@>=1.0.0-rc3 <1.1.0",
+              "from": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc3.tgz",
               "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc3.tgz",
               "dependencies": {
                 "async": {
                   "version": "1.5.2",
-                  "from": "async@>=1.4.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
                   "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
                 }
               }
             },
             "har-validator": {
               "version": "2.0.6",
-              "from": "har-validator@>=2.0.6 <2.1.0",
+              "from": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
               "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
               "dependencies": {
                 "commander": {
                   "version": "2.9.0",
-                  "from": "commander@>=2.9.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
                   "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
                   "dependencies": {
                     "graceful-readlink": {
                       "version": "1.0.1",
-                      "from": "graceful-readlink@>=1.0.0",
+                      "from": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
                     }
                   }
                 },
                 "is-my-json-valid": {
                   "version": "2.12.4",
-                  "from": "is-my-json-valid@>=2.12.4 <3.0.0",
+                  "from": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.4.tgz",
                   "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.4.tgz",
                   "dependencies": {
                     "generate-function": {
                       "version": "2.0.0",
-                      "from": "generate-function@>=2.0.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
                     },
                     "generate-object-property": {
                       "version": "1.2.0",
-                      "from": "generate-object-property@>=1.1.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
                       "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
                       "dependencies": {
                         "is-property": {
                           "version": "1.0.2",
-                          "from": "is-property@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
                           "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
                         }
                       }
                     },
                     "jsonpointer": {
                       "version": "2.0.0",
-                      "from": "jsonpointer@2.0.0",
+                      "from": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz"
                     },
                     "xtend": {
                       "version": "4.0.1",
-                      "from": "xtend@>=4.0.0 <5.0.0",
+                      "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
                     }
                   }
                 },
                 "pinkie-promise": {
                   "version": "2.0.0",
-                  "from": "pinkie-promise@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
                   "dependencies": {
                     "pinkie": {
                       "version": "2.0.4",
-                      "from": "pinkie@>=2.0.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
                       "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
                     }
                   }
@@ -6003,96 +5998,96 @@
             },
             "hawk": {
               "version": "3.1.3",
-              "from": "hawk@>=3.1.0 <3.2.0",
+              "from": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
               "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
               "dependencies": {
                 "hoek": {
                   "version": "2.16.3",
-                  "from": "hoek@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
                   "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
                 },
                 "boom": {
                   "version": "2.10.1",
-                  "from": "boom@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
                   "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
                 },
                 "cryptiles": {
                   "version": "2.0.5",
-                  "from": "cryptiles@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
                   "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
                 },
                 "sntp": {
                   "version": "1.0.9",
-                  "from": "sntp@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
                   "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
                 }
               }
             },
             "http-signature": {
               "version": "1.1.1",
-              "from": "http-signature@>=1.1.0 <1.2.0",
+              "from": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
               "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
               "dependencies": {
                 "assert-plus": {
                   "version": "0.2.0",
-                  "from": "assert-plus@>=0.2.0 <0.3.0",
+                  "from": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
                   "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz"
                 },
                 "jsprim": {
                   "version": "1.2.2",
-                  "from": "jsprim@>=1.2.2 <2.0.0",
+                  "from": "https://registry.npmjs.org/jsprim/-/jsprim-1.2.2.tgz",
                   "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.2.2.tgz",
                   "dependencies": {
                     "extsprintf": {
                       "version": "1.0.2",
-                      "from": "extsprintf@1.0.2",
+                      "from": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
                       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz"
                     },
                     "json-schema": {
                       "version": "0.2.2",
-                      "from": "json-schema@0.2.2",
+                      "from": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.2.tgz",
                       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.2.tgz"
                     },
                     "verror": {
                       "version": "1.3.6",
-                      "from": "verror@1.3.6",
+                      "from": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
                       "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz"
                     }
                   }
                 },
                 "sshpk": {
                   "version": "1.7.3",
-                  "from": "sshpk@>=1.7.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/sshpk/-/sshpk-1.7.3.tgz",
                   "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.7.3.tgz",
                   "dependencies": {
                     "asn1": {
                       "version": "0.2.3",
-                      "from": "asn1@>=0.2.3 <0.3.0",
+                      "from": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
                       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz"
                     },
                     "dashdash": {
                       "version": "1.12.2",
-                      "from": "dashdash@>=1.10.1 <2.0.0",
+                      "from": "https://registry.npmjs.org/dashdash/-/dashdash-1.12.2.tgz",
                       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.12.2.tgz"
                     },
                     "jsbn": {
                       "version": "0.1.0",
-                      "from": "jsbn@>=0.1.0 <0.2.0",
+                      "from": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz",
                       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz"
                     },
                     "tweetnacl": {
                       "version": "0.13.3",
-                      "from": "tweetnacl@>=0.13.0 <1.0.0",
+                      "from": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.13.3.tgz",
                       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.13.3.tgz"
                     },
                     "jodid25519": {
                       "version": "1.0.2",
-                      "from": "jodid25519@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
                       "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz"
                     },
                     "ecc-jsbn": {
                       "version": "0.1.1",
-                      "from": "ecc-jsbn@>=0.0.1 <1.0.0",
+                      "from": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
                       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz"
                     }
                   }
@@ -6101,108 +6096,108 @@
             },
             "is-typedarray": {
               "version": "1.0.0",
-              "from": "is-typedarray@>=1.0.0 <1.1.0",
+              "from": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz"
             },
             "isstream": {
               "version": "0.1.2",
-              "from": "isstream@>=0.1.2 <0.2.0",
+              "from": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
               "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
             },
             "json-stringify-safe": {
               "version": "5.0.1",
-              "from": "json-stringify-safe@>=5.0.1 <5.1.0",
+              "from": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
               "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
             },
             "mime-types": {
               "version": "2.1.9",
-              "from": "mime-types@>=2.1.7 <2.2.0",
+              "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.9.tgz",
               "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.9.tgz",
               "dependencies": {
                 "mime-db": {
                   "version": "1.21.0",
-                  "from": "mime-db@>=1.21.0 <1.22.0",
+                  "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.21.0.tgz",
                   "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.21.0.tgz"
                 }
               }
             },
             "node-uuid": {
               "version": "1.4.7",
-              "from": "node-uuid@>=1.4.7 <1.5.0",
+              "from": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz",
               "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz"
             },
             "oauth-sign": {
               "version": "0.8.1",
-              "from": "oauth-sign@>=0.8.0 <0.9.0",
+              "from": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.1.tgz",
               "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.1.tgz"
             },
             "qs": {
               "version": "6.0.2",
-              "from": "qs@>=6.0.2 <6.1.0",
+              "from": "https://registry.npmjs.org/qs/-/qs-6.0.2.tgz",
               "resolved": "https://registry.npmjs.org/qs/-/qs-6.0.2.tgz"
             },
             "stringstream": {
               "version": "0.0.5",
-              "from": "stringstream@>=0.0.4 <0.1.0",
+              "from": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
               "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
             },
             "tough-cookie": {
               "version": "2.2.1",
-              "from": "tough-cookie@>=2.2.0 <2.3.0",
+              "from": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.1.tgz",
               "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.1.tgz"
             },
             "tunnel-agent": {
               "version": "0.4.2",
-              "from": "tunnel-agent@>=0.4.1 <0.5.0",
+              "from": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.2.tgz",
               "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.2.tgz"
             }
           }
         },
         "sass-graph": {
           "version": "2.1.1",
-          "from": "sass-graph@>=2.0.1 <3.0.0",
+          "from": "https://registry.npmjs.org/sass-graph/-/sass-graph-2.1.1.tgz",
           "resolved": "https://registry.npmjs.org/sass-graph/-/sass-graph-2.1.1.tgz",
           "dependencies": {
             "glob": {
               "version": "6.0.4",
-              "from": "glob@>=6.0.4 <7.0.0",
+              "from": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
               "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
               "dependencies": {
                 "inflight": {
                   "version": "1.0.4",
-                  "from": "inflight@>=1.0.4 <2.0.0",
+                  "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
                   "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
                   "dependencies": {
                     "wrappy": {
                       "version": "1.0.1",
-                      "from": "wrappy@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                     }
                   }
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "minimatch": {
                   "version": "3.0.0",
-                  "from": "minimatch@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0",
+                  "from": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
                   "dependencies": {
                     "brace-expansion": {
                       "version": "1.1.2",
-                      "from": "brace-expansion@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.2.tgz",
                       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.2.tgz",
                       "dependencies": {
                         "balanced-match": {
                           "version": "0.3.0",
-                          "from": "balanced-match@>=0.3.0 <0.4.0",
+                          "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz",
                           "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
                         },
                         "concat-map": {
                           "version": "0.0.1",
-                          "from": "concat-map@0.0.1",
+                          "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                         }
                       }
@@ -6211,87 +6206,87 @@
                 },
                 "once": {
                   "version": "1.3.3",
-                  "from": "once@>=1.3.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
                   "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
                   "dependencies": {
                     "wrappy": {
                       "version": "1.0.1",
-                      "from": "wrappy@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                     }
                   }
                 },
                 "path-is-absolute": {
                   "version": "1.0.0",
-                  "from": "path-is-absolute@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
                 }
               }
             },
             "lodash": {
               "version": "4.2.1",
-              "from": "lodash@>=4.0.0 <5.0.0",
+              "from": "https://registry.npmjs.org/lodash/-/lodash-4.2.1.tgz",
               "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.2.1.tgz"
             },
             "yargs": {
               "version": "3.32.0",
-              "from": "yargs@>=3.8.0 <4.0.0",
+              "from": "https://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
               "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
               "dependencies": {
                 "camelcase": {
                   "version": "2.1.0",
-                  "from": "camelcase@>=2.0.1 <3.0.0",
+                  "from": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.0.tgz"
                 },
                 "cliui": {
                   "version": "3.1.0",
-                  "from": "cliui@>=3.0.3 <4.0.0",
+                  "from": "https://registry.npmjs.org/cliui/-/cliui-3.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.1.0.tgz",
                   "dependencies": {
                     "strip-ansi": {
                       "version": "3.0.0",
-                      "from": "strip-ansi@>=3.0.0 <4.0.0",
+                      "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
                       "dependencies": {
                         "ansi-regex": {
                           "version": "2.0.0",
-                          "from": "ansi-regex@>=2.0.0 <3.0.0",
+                          "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                         }
                       }
                     },
                     "wrap-ansi": {
                       "version": "1.0.0",
-                      "from": "wrap-ansi@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-1.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-1.0.0.tgz"
                     }
                   }
                 },
                 "decamelize": {
                   "version": "1.1.2",
-                  "from": "decamelize@>=1.1.1 <2.0.0",
+                  "from": "https://registry.npmjs.org/decamelize/-/decamelize-1.1.2.tgz",
                   "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.1.2.tgz",
                   "dependencies": {
                     "escape-string-regexp": {
                       "version": "1.0.4",
-                      "from": "escape-string-regexp@>=1.0.4 <2.0.0",
+                      "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz",
                       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz"
                     }
                   }
                 },
                 "os-locale": {
                   "version": "1.4.0",
-                  "from": "os-locale@>=1.4.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
                   "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
                   "dependencies": {
                     "lcid": {
                       "version": "1.0.0",
-                      "from": "lcid@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
                       "dependencies": {
                         "invert-kv": {
                           "version": "1.0.0",
-                          "from": "invert-kv@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz"
                         }
                       }
@@ -6300,41 +6295,41 @@
                 },
                 "string-width": {
                   "version": "1.0.1",
-                  "from": "string-width@>=1.0.1 <2.0.0",
+                  "from": "https://registry.npmjs.org/string-width/-/string-width-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.1.tgz",
                   "dependencies": {
                     "code-point-at": {
                       "version": "1.0.0",
-                      "from": "code-point-at@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.0.0.tgz",
                       "dependencies": {
                         "number-is-nan": {
                           "version": "1.0.0",
-                          "from": "number-is-nan@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
                         }
                       }
                     },
                     "is-fullwidth-code-point": {
                       "version": "1.0.0",
-                      "from": "is-fullwidth-code-point@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
                       "dependencies": {
                         "number-is-nan": {
                           "version": "1.0.0",
-                          "from": "number-is-nan@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
                         }
                       }
                     },
                     "strip-ansi": {
                       "version": "3.0.0",
-                      "from": "strip-ansi@>=3.0.0 <4.0.0",
+                      "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
                       "dependencies": {
                         "ansi-regex": {
                           "version": "2.0.0",
-                          "from": "ansi-regex@>=2.0.0 <3.0.0",
+                          "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                         }
                       }
@@ -6343,12 +6338,12 @@
                 },
                 "window-size": {
                   "version": "0.1.4",
-                  "from": "window-size@>=0.1.4 <0.2.0",
+                  "from": "https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz",
                   "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz"
                 },
                 "y18n": {
                   "version": "3.2.0",
-                  "from": "y18n@>=3.2.0 <4.0.0",
+                  "from": "https://registry.npmjs.org/y18n/-/y18n-3.2.0.tgz",
                   "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.0.tgz"
                 }
               }
@@ -6359,7 +6354,7 @@
     },
     "react": {
       "version": "0.14.7",
-      "from": "react@>=0.14.2 <0.15.0",
+      "from": "https://registry.npmjs.org/react/-/react-0.14.7.tgz",
       "resolved": "https://registry.npmjs.org/react/-/react-0.14.7.tgz",
       "dependencies": {
         "envify": {
@@ -6453,47 +6448,47 @@
     },
     "react-addons": {
       "version": "0.9.1-deprecated",
-      "from": "react-addons@>=0.9.1-deprecated <0.10.0",
+      "from": "https://registry.npmjs.org/react-addons/-/react-addons-0.9.1-deprecated.tgz",
       "resolved": "https://registry.npmjs.org/react-addons/-/react-addons-0.9.1-deprecated.tgz"
     },
     "react-dom": {
       "version": "0.14.7",
-      "from": "react-dom@>=0.14.2 <0.15.0",
+      "from": "https://registry.npmjs.org/react-dom/-/react-dom-0.14.7.tgz",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-0.14.7.tgz"
     },
     "react-ga": {
       "version": "1.2.0",
-      "from": "react-ga@>=1.2.0 <2.0.0",
+      "from": "https://registry.npmjs.org/react-ga/-/react-ga-1.2.0.tgz",
       "resolved": "https://registry.npmjs.org/react-ga/-/react-ga-1.2.0.tgz"
     },
     "react-redux": {
       "version": "4.2.1",
-      "from": "react-redux@>=4.0.0 <5.0.0",
+      "from": "https://registry.npmjs.org/react-redux/-/react-redux-4.2.1.tgz",
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-4.2.1.tgz",
       "dependencies": {
         "hoist-non-react-statics": {
           "version": "1.0.5",
-          "from": "hoist-non-react-statics@>=1.0.3 <2.0.0",
+          "from": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-1.0.5.tgz",
           "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-1.0.5.tgz"
         },
         "invariant": {
           "version": "2.2.0",
-          "from": "invariant@>=2.0.0 <3.0.0",
+          "from": "https://registry.npmjs.org/invariant/-/invariant-2.2.0.tgz",
           "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.0.tgz"
         },
         "lodash": {
           "version": "4.2.1",
-          "from": "lodash@>=4.2.0 <5.0.0",
+          "from": "https://registry.npmjs.org/lodash/-/lodash-4.2.1.tgz",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.2.1.tgz"
         },
         "loose-envify": {
           "version": "1.1.0",
-          "from": "loose-envify@>=1.1.0 <2.0.0",
+          "from": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz",
           "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz",
           "dependencies": {
             "js-tokens": {
               "version": "1.0.2",
-              "from": "js-tokens@>=1.0.1 <2.0.0",
+              "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz",
               "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
             }
           }
@@ -6502,22 +6497,22 @@
     },
     "react-router": {
       "version": "1.0.3",
-      "from": "react-router@>=1.0.0 <1.1.0",
+      "from": "https://registry.npmjs.org/react-router/-/react-router-1.0.3.tgz",
       "resolved": "https://registry.npmjs.org/react-router/-/react-router-1.0.3.tgz",
       "dependencies": {
         "invariant": {
           "version": "2.2.0",
-          "from": "invariant@>=2.0.0 <3.0.0",
+          "from": "https://registry.npmjs.org/invariant/-/invariant-2.2.0.tgz",
           "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.0.tgz",
           "dependencies": {
             "loose-envify": {
               "version": "1.1.0",
-              "from": "loose-envify@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz",
               "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz",
               "dependencies": {
                 "js-tokens": {
                   "version": "1.0.2",
-                  "from": "js-tokens@>=1.0.1 <2.0.0",
+                  "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
                 }
               }
@@ -6526,17 +6521,17 @@
         },
         "warning": {
           "version": "2.1.0",
-          "from": "warning@>=2.0.0 <3.0.0",
+          "from": "https://registry.npmjs.org/warning/-/warning-2.1.0.tgz",
           "resolved": "https://registry.npmjs.org/warning/-/warning-2.1.0.tgz",
           "dependencies": {
             "loose-envify": {
               "version": "1.1.0",
-              "from": "loose-envify@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz",
               "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz",
               "dependencies": {
                 "js-tokens": {
                   "version": "1.0.2",
-                  "from": "js-tokens@>=1.0.1 <2.0.0",
+                  "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
                 }
               }
@@ -6547,34 +6542,34 @@
     },
     "react-tap-event-plugin": {
       "version": "0.2.2",
-      "from": "react-tap-event-plugin@>=0.2.1 <0.3.0",
+      "from": "https://registry.npmjs.org/react-tap-event-plugin/-/react-tap-event-plugin-0.2.2.tgz",
       "resolved": "https://registry.npmjs.org/react-tap-event-plugin/-/react-tap-event-plugin-0.2.2.tgz",
       "dependencies": {
         "fbjs": {
           "version": "0.2.1",
-          "from": "fbjs@>=0.2.1 <0.3.0",
+          "from": "https://registry.npmjs.org/fbjs/-/fbjs-0.2.1.tgz",
           "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.2.1.tgz",
           "dependencies": {
             "core-js": {
               "version": "1.2.6",
-              "from": "core-js@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz",
               "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
             },
             "promise": {
               "version": "7.1.1",
-              "from": "promise@>=7.0.3 <8.0.0",
+              "from": "https://registry.npmjs.org/promise/-/promise-7.1.1.tgz",
               "resolved": "https://registry.npmjs.org/promise/-/promise-7.1.1.tgz",
               "dependencies": {
                 "asap": {
                   "version": "2.0.3",
-                  "from": "asap@>=2.0.3 <2.1.0",
+                  "from": "https://registry.npmjs.org/asap/-/asap-2.0.3.tgz",
                   "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.3.tgz"
                 }
               }
             },
             "whatwg-fetch": {
               "version": "0.9.0",
-              "from": "whatwg-fetch@>=0.9.0 <0.10.0",
+              "from": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-0.9.0.tgz",
               "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-0.9.0.tgz"
             }
           }
@@ -6583,22 +6578,22 @@
     },
     "redux": {
       "version": "3.2.1",
-      "from": "redux@>=3.0.4 <4.0.0",
+      "from": "https://registry.npmjs.org/redux/-/redux-3.2.1.tgz",
       "resolved": "https://registry.npmjs.org/redux/-/redux-3.2.1.tgz",
       "dependencies": {
         "lodash": {
           "version": "4.2.1",
-          "from": "lodash@>=4.2.0 <5.0.0",
+          "from": "https://registry.npmjs.org/lodash/-/lodash-4.2.1.tgz",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.2.1.tgz"
         },
         "loose-envify": {
           "version": "1.1.0",
-          "from": "loose-envify@>=1.1.0 <2.0.0",
+          "from": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz",
           "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz",
           "dependencies": {
             "js-tokens": {
               "version": "1.0.2",
-              "from": "js-tokens@>=1.0.1 <2.0.0",
+              "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz",
               "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
             }
           }
@@ -6607,17 +6602,17 @@
     },
     "redux-actions": {
       "version": "0.9.1",
-      "from": "redux-actions@>=0.9.0 <0.10.0",
+      "from": "https://registry.npmjs.org/redux-actions/-/redux-actions-0.9.1.tgz",
       "resolved": "https://registry.npmjs.org/redux-actions/-/redux-actions-0.9.1.tgz",
       "dependencies": {
         "flux-standard-action": {
           "version": "0.6.1",
-          "from": "flux-standard-action@>=0.6.0 <0.7.0",
+          "from": "https://registry.npmjs.org/flux-standard-action/-/flux-standard-action-0.6.1.tgz",
           "resolved": "https://registry.npmjs.org/flux-standard-action/-/flux-standard-action-0.6.1.tgz",
           "dependencies": {
             "lodash.isplainobject": {
               "version": "3.2.0",
-              "from": "lodash.isplainobject@>=3.2.0 <4.0.0",
+              "from": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-3.2.0.tgz",
               "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-3.2.0.tgz",
               "dependencies": {
                 "lodash._basefor": {
@@ -6637,7 +6632,7 @@
                   "dependencies": {
                     "lodash.isarray": {
                       "version": "3.0.4",
-                      "from": "lodash.isarray@>=3.0.0 <4.0.0",
+                      "from": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
                       "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
                     }
                   }
@@ -6648,29 +6643,29 @@
         },
         "reduce-reducers": {
           "version": "0.1.2",
-          "from": "reduce-reducers@>=0.1.0 <0.2.0",
+          "from": "https://registry.npmjs.org/reduce-reducers/-/reduce-reducers-0.1.2.tgz",
           "resolved": "https://registry.npmjs.org/reduce-reducers/-/reduce-reducers-0.1.2.tgz"
         }
       }
     },
     "redux-devtools": {
       "version": "2.1.5",
-      "from": "redux-devtools@>=2.1.5 <3.0.0",
+      "from": "https://registry.npmjs.org/redux-devtools/-/redux-devtools-2.1.5.tgz",
       "resolved": "https://registry.npmjs.org/redux-devtools/-/redux-devtools-2.1.5.tgz",
       "dependencies": {
         "react-json-tree": {
           "version": "0.1.9",
-          "from": "react-json-tree@>=0.1.9 <0.2.0",
+          "from": "https://registry.npmjs.org/react-json-tree/-/react-json-tree-0.1.9.tgz",
           "resolved": "https://registry.npmjs.org/react-json-tree/-/react-json-tree-0.1.9.tgz",
           "dependencies": {
             "babel-runtime": {
               "version": "5.8.35",
-              "from": "babel-runtime@>=5.8.20 <6.0.0",
+              "from": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.35.tgz",
               "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.35.tgz",
               "dependencies": {
                 "core-js": {
                   "version": "1.2.6",
-                  "from": "core-js@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz",
                   "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
                 }
               }
@@ -6679,47 +6674,76 @@
         },
         "react-mixin": {
           "version": "1.7.0",
-          "from": "react-mixin@>=1.7.0 <2.0.0",
+          "from": "https://registry.npmjs.org/react-mixin/-/react-mixin-1.7.0.tgz",
           "resolved": "https://registry.npmjs.org/react-mixin/-/react-mixin-1.7.0.tgz",
           "dependencies": {
             "object-assign": {
               "version": "2.1.1",
-              "from": "object-assign@>=2.0.0 <3.0.0",
+              "from": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz",
               "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz"
             },
             "smart-mixin": {
               "version": "1.2.1",
-              "from": "smart-mixin@>=1.2.0 <2.0.0",
+              "from": "https://registry.npmjs.org/smart-mixin/-/smart-mixin-1.2.1.tgz",
               "resolved": "https://registry.npmjs.org/smart-mixin/-/smart-mixin-1.2.1.tgz"
             }
           }
         },
         "react-redux": {
           "version": "3.1.2",
-          "from": "react-redux@>=3.0.0 <4.0.0",
+          "from": "https://registry.npmjs.org/react-redux/-/react-redux-3.1.2.tgz",
           "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-3.1.2.tgz",
           "dependencies": {
             "hoist-non-react-statics": {
               "version": "1.0.5",
-              "from": "hoist-non-react-statics@>=1.0.3 <2.0.0",
+              "from": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-1.0.5.tgz",
               "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-1.0.5.tgz"
             },
             "invariant": {
               "version": "2.2.0",
-              "from": "invariant@>=2.2.0 <3.0.0",
+              "from": "https://registry.npmjs.org/invariant/-/invariant-2.2.0.tgz",
               "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.0.tgz",
               "dependencies": {
                 "loose-envify": {
                   "version": "1.1.0",
-                  "from": "loose-envify@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz",
                   "dependencies": {
                     "js-tokens": {
                       "version": "1.0.2",
-                      "from": "js-tokens@>=1.0.1 <2.0.0",
+                      "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz",
                       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
                     }
                   }
+                }
+              }
+            }
+          }
+        },
+        "redux": {
+          "version": "3.3.1",
+          "from": "redux@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/redux/-/redux-3.3.1.tgz",
+          "dependencies": {
+            "lodash": {
+              "version": "4.3.0",
+              "from": "lodash@>=4.2.1 <5.0.0",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.3.0.tgz"
+            },
+            "lodash-es": {
+              "version": "4.3.0",
+              "from": "lodash-es@>=4.2.1 <5.0.0",
+              "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.3.0.tgz"
+            },
+            "loose-envify": {
+              "version": "1.1.0",
+              "from": "loose-envify@>=1.1.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz",
+              "dependencies": {
+                "js-tokens": {
+                  "version": "1.0.2",
+                  "from": "js-tokens@>=1.0.1 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
                 }
               }
             }
@@ -6729,71 +6753,71 @@
     },
     "redux-localstorage": {
       "version": "0.4.0",
-      "from": "redux-localstorage@>=0.4.0 <0.5.0",
+      "from": "https://registry.npmjs.org/redux-localstorage/-/redux-localstorage-0.4.0.tgz",
       "resolved": "https://registry.npmjs.org/redux-localstorage/-/redux-localstorage-0.4.0.tgz"
     },
     "redux-logger": {
       "version": "2.0.5",
-      "from": "redux-logger@>=2.0.4 <2.1.0",
+      "from": "https://registry.npmjs.org/redux-logger/-/redux-logger-2.0.5.tgz",
       "resolved": "https://registry.npmjs.org/redux-logger/-/redux-logger-2.0.5.tgz"
     },
     "redux-thunk": {
       "version": "1.0.3",
-      "from": "redux-thunk@>=1.0.0 <1.1.0",
+      "from": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-1.0.3.tgz",
       "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-1.0.3.tgz"
     },
     "sass-loader": {
       "version": "3.1.2",
-      "from": "sass-loader@>=3.1.1 <4.0.0",
+      "from": "https://registry.npmjs.org/sass-loader/-/sass-loader-3.1.2.tgz",
       "resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-3.1.2.tgz",
       "dependencies": {
         "async": {
           "version": "1.5.2",
-          "from": "async@>=1.4.0 <2.0.0",
+          "from": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
           "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
         },
         "loader-utils": {
           "version": "0.2.12",
-          "from": "loader-utils@>=0.2.11 <0.3.0",
+          "from": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.12.tgz",
           "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.12.tgz",
           "dependencies": {
             "big.js": {
               "version": "3.1.3",
-              "from": "big.js@>=3.0.2 <4.0.0",
+              "from": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz",
               "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz"
             },
             "json5": {
               "version": "0.4.0",
-              "from": "json5@>=0.4.0 <0.5.0",
+              "from": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz",
               "resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz"
             }
           }
         },
         "object-assign": {
           "version": "4.0.1",
-          "from": "object-assign@>=4.0.1 <5.0.0",
+          "from": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz",
           "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz"
         }
       }
     },
     "style-loader": {
       "version": "0.13.0",
-      "from": "style-loader@>=0.13.0 <0.14.0",
+      "from": "https://registry.npmjs.org/style-loader/-/style-loader-0.13.0.tgz",
       "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-0.13.0.tgz",
       "dependencies": {
         "loader-utils": {
           "version": "0.2.12",
-          "from": "loader-utils@>=0.2.7 <0.3.0",
+          "from": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.12.tgz",
           "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.12.tgz",
           "dependencies": {
             "big.js": {
               "version": "3.1.3",
-              "from": "big.js@>=3.0.2 <4.0.0",
+              "from": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz",
               "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz"
             },
             "json5": {
               "version": "0.4.0",
-              "from": "json5@>=0.4.0 <0.5.0",
+              "from": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz",
               "resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz"
             }
           }
@@ -7592,9 +7616,9 @@
                       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
                       "dependencies": {
                         "brace-expansion": {
-                          "version": "1.1.2",
+                          "version": "1.1.3",
                           "from": "brace-expansion@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.2.tgz",
+                          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
                           "dependencies": {
                             "balanced-match": {
                               "version": "0.3.0",
@@ -7681,17 +7705,17 @@
     },
     "webpack-bundle-tracker": {
       "version": "0.0.8",
-      "from": "webpack-bundle-tracker@0.0.8",
+      "from": "https://registry.npmjs.org/webpack-bundle-tracker/-/webpack-bundle-tracker-0.0.8.tgz",
       "resolved": "https://registry.npmjs.org/webpack-bundle-tracker/-/webpack-bundle-tracker-0.0.8.tgz",
       "dependencies": {
         "strip-ansi": {
           "version": "2.0.1",
-          "from": "strip-ansi@>=2.0.1 <3.0.0",
+          "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
           "dependencies": {
             "ansi-regex": {
               "version": "1.1.1",
-              "from": "ansi-regex@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz",
               "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
             }
           }
@@ -7700,303 +7724,303 @@
     },
     "webpack-dev-server": {
       "version": "1.14.1",
-      "from": "webpack-dev-server@>=1.12.1 <2.0.0",
+      "from": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-1.14.1.tgz",
       "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-1.14.1.tgz",
       "dependencies": {
         "compression": {
           "version": "1.6.1",
-          "from": "compression@>=1.5.2 <2.0.0",
+          "from": "https://registry.npmjs.org/compression/-/compression-1.6.1.tgz",
           "resolved": "https://registry.npmjs.org/compression/-/compression-1.6.1.tgz",
           "dependencies": {
             "accepts": {
               "version": "1.3.1",
-              "from": "accepts@>=1.3.1 <1.4.0",
+              "from": "https://registry.npmjs.org/accepts/-/accepts-1.3.1.tgz",
               "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.1.tgz",
               "dependencies": {
                 "mime-types": {
                   "version": "2.1.9",
-                  "from": "mime-types@>=2.1.9 <2.2.0",
+                  "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.9.tgz",
                   "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.9.tgz",
                   "dependencies": {
                     "mime-db": {
                       "version": "1.21.0",
-                      "from": "mime-db@>=1.21.0 <1.22.0",
+                      "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.21.0.tgz",
                       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.21.0.tgz"
                     }
                   }
                 },
                 "negotiator": {
                   "version": "0.6.0",
-                  "from": "negotiator@0.6.0",
+                  "from": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.0.tgz",
                   "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.0.tgz"
                 }
               }
             },
             "bytes": {
               "version": "2.2.0",
-              "from": "bytes@2.2.0",
+              "from": "https://registry.npmjs.org/bytes/-/bytes-2.2.0.tgz",
               "resolved": "https://registry.npmjs.org/bytes/-/bytes-2.2.0.tgz"
             },
             "compressible": {
               "version": "2.0.7",
-              "from": "compressible@>=2.0.7 <2.1.0",
+              "from": "https://registry.npmjs.org/compressible/-/compressible-2.0.7.tgz",
               "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.7.tgz",
               "dependencies": {
                 "mime-db": {
                   "version": "1.21.0",
-                  "from": "mime-db@>=1.21.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.21.0.tgz",
                   "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.21.0.tgz"
                 }
               }
             },
             "debug": {
               "version": "2.2.0",
-              "from": "debug@>=2.2.0 <2.3.0",
+              "from": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
               "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
               "dependencies": {
                 "ms": {
                   "version": "0.7.1",
-                  "from": "ms@0.7.1",
+                  "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
                   "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
                 }
               }
             },
             "on-headers": {
               "version": "1.0.1",
-              "from": "on-headers@>=1.0.1 <1.1.0",
+              "from": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.1.tgz",
               "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.1.tgz"
             },
             "vary": {
               "version": "1.1.0",
-              "from": "vary@>=1.1.0 <1.2.0",
+              "from": "https://registry.npmjs.org/vary/-/vary-1.1.0.tgz",
               "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.0.tgz"
             }
           }
         },
         "connect-history-api-fallback": {
           "version": "1.1.0",
-          "from": "connect-history-api-fallback@1.1.0",
+          "from": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-1.1.0.tgz",
           "resolved": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-1.1.0.tgz"
         },
         "express": {
           "version": "4.13.4",
-          "from": "express@>=4.13.3 <5.0.0",
+          "from": "https://registry.npmjs.org/express/-/express-4.13.4.tgz",
           "resolved": "https://registry.npmjs.org/express/-/express-4.13.4.tgz",
           "dependencies": {
             "accepts": {
               "version": "1.2.13",
-              "from": "accepts@>=1.2.12 <1.3.0",
+              "from": "https://registry.npmjs.org/accepts/-/accepts-1.2.13.tgz",
               "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.2.13.tgz",
               "dependencies": {
                 "mime-types": {
                   "version": "2.1.9",
-                  "from": "mime-types@>=2.1.9 <2.2.0",
+                  "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.9.tgz",
                   "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.9.tgz",
                   "dependencies": {
                     "mime-db": {
                       "version": "1.21.0",
-                      "from": "mime-db@>=1.21.0 <1.22.0",
+                      "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.21.0.tgz",
                       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.21.0.tgz"
                     }
                   }
                 },
                 "negotiator": {
                   "version": "0.5.3",
-                  "from": "negotiator@0.5.3",
+                  "from": "https://registry.npmjs.org/negotiator/-/negotiator-0.5.3.tgz",
                   "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.5.3.tgz"
                 }
               }
             },
             "array-flatten": {
               "version": "1.1.1",
-              "from": "array-flatten@1.1.1",
+              "from": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
               "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz"
             },
             "content-disposition": {
               "version": "0.5.1",
-              "from": "content-disposition@0.5.1",
+              "from": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.1.tgz",
               "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.1.tgz"
             },
             "content-type": {
               "version": "1.0.1",
-              "from": "content-type@>=1.0.1 <1.1.0",
+              "from": "https://registry.npmjs.org/content-type/-/content-type-1.0.1.tgz",
               "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.1.tgz"
             },
             "cookie": {
               "version": "0.1.5",
-              "from": "cookie@0.1.5",
+              "from": "https://registry.npmjs.org/cookie/-/cookie-0.1.5.tgz",
               "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.1.5.tgz"
             },
             "cookie-signature": {
               "version": "1.0.6",
-              "from": "cookie-signature@1.0.6",
+              "from": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
               "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz"
             },
             "debug": {
               "version": "2.2.0",
-              "from": "debug@>=2.2.0 <2.3.0",
+              "from": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
               "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
               "dependencies": {
                 "ms": {
                   "version": "0.7.1",
-                  "from": "ms@0.7.1",
+                  "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
                   "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
                 }
               }
             },
             "depd": {
               "version": "1.1.0",
-              "from": "depd@>=1.1.0 <1.2.0",
+              "from": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz",
               "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz"
             },
             "escape-html": {
               "version": "1.0.3",
-              "from": "escape-html@>=1.0.3 <1.1.0",
+              "from": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
               "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz"
             },
             "etag": {
               "version": "1.7.0",
-              "from": "etag@>=1.7.0 <1.8.0",
+              "from": "https://registry.npmjs.org/etag/-/etag-1.7.0.tgz",
               "resolved": "https://registry.npmjs.org/etag/-/etag-1.7.0.tgz"
             },
             "finalhandler": {
               "version": "0.4.1",
-              "from": "finalhandler@0.4.1",
+              "from": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.4.1.tgz",
               "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.4.1.tgz",
               "dependencies": {
                 "unpipe": {
                   "version": "1.0.0",
-                  "from": "unpipe@>=1.0.0 <1.1.0",
+                  "from": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz"
                 }
               }
             },
             "fresh": {
               "version": "0.3.0",
-              "from": "fresh@0.3.0",
+              "from": "https://registry.npmjs.org/fresh/-/fresh-0.3.0.tgz",
               "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.3.0.tgz"
             },
             "merge-descriptors": {
               "version": "1.0.1",
-              "from": "merge-descriptors@1.0.1",
+              "from": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
               "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz"
             },
             "methods": {
               "version": "1.1.2",
-              "from": "methods@>=1.1.2 <1.2.0",
+              "from": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
               "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz"
             },
             "on-finished": {
               "version": "2.3.0",
-              "from": "on-finished@>=2.3.0 <2.4.0",
+              "from": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
               "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
               "dependencies": {
                 "ee-first": {
                   "version": "1.1.1",
-                  "from": "ee-first@1.1.1",
+                  "from": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
                   "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz"
                 }
               }
             },
             "parseurl": {
               "version": "1.3.1",
-              "from": "parseurl@>=1.3.1 <1.4.0",
+              "from": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz",
               "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz"
             },
             "path-to-regexp": {
               "version": "0.1.7",
-              "from": "path-to-regexp@0.1.7",
+              "from": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
               "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz"
             },
             "proxy-addr": {
               "version": "1.0.10",
-              "from": "proxy-addr@>=1.0.10 <1.1.0",
+              "from": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.0.10.tgz",
               "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.0.10.tgz",
               "dependencies": {
                 "forwarded": {
                   "version": "0.1.0",
-                  "from": "forwarded@>=0.1.0 <0.2.0",
+                  "from": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.0.tgz"
                 },
                 "ipaddr.js": {
                   "version": "1.0.5",
-                  "from": "ipaddr.js@1.0.5",
+                  "from": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.0.5.tgz",
                   "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.0.5.tgz"
                 }
               }
             },
             "qs": {
               "version": "4.0.0",
-              "from": "qs@4.0.0",
+              "from": "https://registry.npmjs.org/qs/-/qs-4.0.0.tgz",
               "resolved": "https://registry.npmjs.org/qs/-/qs-4.0.0.tgz"
             },
             "range-parser": {
               "version": "1.0.3",
-              "from": "range-parser@>=1.0.3 <1.1.0",
+              "from": "https://registry.npmjs.org/range-parser/-/range-parser-1.0.3.tgz",
               "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.0.3.tgz"
             },
             "send": {
               "version": "0.13.1",
-              "from": "send@0.13.1",
+              "from": "https://registry.npmjs.org/send/-/send-0.13.1.tgz",
               "resolved": "https://registry.npmjs.org/send/-/send-0.13.1.tgz",
               "dependencies": {
                 "destroy": {
                   "version": "1.0.4",
-                  "from": "destroy@>=1.0.4 <1.1.0",
+                  "from": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
                   "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz"
                 },
                 "http-errors": {
                   "version": "1.3.1",
-                  "from": "http-errors@>=1.3.1 <1.4.0",
+                  "from": "https://registry.npmjs.org/http-errors/-/http-errors-1.3.1.tgz",
                   "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.3.1.tgz",
                   "dependencies": {
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@>=2.0.1 <2.1.0",
+                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     }
                   }
                 },
                 "mime": {
                   "version": "1.3.4",
-                  "from": "mime@1.3.4",
+                  "from": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
                   "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz"
                 },
                 "ms": {
                   "version": "0.7.1",
-                  "from": "ms@0.7.1",
+                  "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
                   "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
                 },
                 "statuses": {
                   "version": "1.2.1",
-                  "from": "statuses@>=1.2.1 <1.3.0",
+                  "from": "https://registry.npmjs.org/statuses/-/statuses-1.2.1.tgz",
                   "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.2.1.tgz"
                 }
               }
             },
             "serve-static": {
               "version": "1.10.2",
-              "from": "serve-static@>=1.10.2 <1.11.0",
+              "from": "https://registry.npmjs.org/serve-static/-/serve-static-1.10.2.tgz",
               "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.10.2.tgz"
             },
             "type-is": {
               "version": "1.6.11",
-              "from": "type-is@>=1.6.6 <1.7.0",
+              "from": "https://registry.npmjs.org/type-is/-/type-is-1.6.11.tgz",
               "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.11.tgz",
               "dependencies": {
                 "media-typer": {
                   "version": "0.3.0",
-                  "from": "media-typer@0.3.0",
+                  "from": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
                   "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz"
                 },
                 "mime-types": {
                   "version": "2.1.9",
-                  "from": "mime-types@>=2.1.9 <2.2.0",
+                  "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.9.tgz",
                   "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.9.tgz",
                   "dependencies": {
                     "mime-db": {
                       "version": "1.21.0",
-                      "from": "mime-db@>=1.21.0 <1.22.0",
+                      "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.21.0.tgz",
                       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.21.0.tgz"
                     }
                   }
@@ -8005,143 +8029,143 @@
             },
             "utils-merge": {
               "version": "1.0.0",
-              "from": "utils-merge@1.0.0",
+              "from": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz"
             },
             "vary": {
               "version": "1.0.1",
-              "from": "vary@>=1.0.1 <1.1.0",
+              "from": "https://registry.npmjs.org/vary/-/vary-1.0.1.tgz",
               "resolved": "https://registry.npmjs.org/vary/-/vary-1.0.1.tgz"
             }
           }
         },
         "http-proxy": {
           "version": "1.13.1",
-          "from": "http-proxy@>=1.11.2 <2.0.0",
+          "from": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.13.1.tgz",
           "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.13.1.tgz",
           "dependencies": {
             "eventemitter3": {
               "version": "1.1.1",
-              "from": "eventemitter3@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-1.1.1.tgz",
               "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-1.1.1.tgz"
             },
             "requires-port": {
               "version": "1.0.0",
-              "from": "requires-port@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz"
             }
           }
         },
         "optimist": {
           "version": "0.6.1",
-          "from": "optimist@>=0.6.0 <0.7.0",
+          "from": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
           "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
           "dependencies": {
             "wordwrap": {
               "version": "0.0.3",
-              "from": "wordwrap@>=0.0.2 <0.1.0",
+              "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
               "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
             },
             "minimist": {
               "version": "0.0.10",
-              "from": "minimist@>=0.0.1 <0.1.0",
+              "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
               "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
             }
           }
         },
         "serve-index": {
           "version": "1.7.3",
-          "from": "serve-index@>=1.7.2 <2.0.0",
+          "from": "https://registry.npmjs.org/serve-index/-/serve-index-1.7.3.tgz",
           "resolved": "https://registry.npmjs.org/serve-index/-/serve-index-1.7.3.tgz",
           "dependencies": {
             "accepts": {
               "version": "1.2.13",
-              "from": "accepts@>=1.2.13 <1.3.0",
+              "from": "https://registry.npmjs.org/accepts/-/accepts-1.2.13.tgz",
               "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.2.13.tgz",
               "dependencies": {
                 "negotiator": {
                   "version": "0.5.3",
-                  "from": "negotiator@0.5.3",
+                  "from": "https://registry.npmjs.org/negotiator/-/negotiator-0.5.3.tgz",
                   "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.5.3.tgz"
                 }
               }
             },
             "batch": {
               "version": "0.5.3",
-              "from": "batch@0.5.3",
+              "from": "https://registry.npmjs.org/batch/-/batch-0.5.3.tgz",
               "resolved": "https://registry.npmjs.org/batch/-/batch-0.5.3.tgz"
             },
             "debug": {
               "version": "2.2.0",
-              "from": "debug@>=2.2.0 <2.3.0",
+              "from": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
               "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
               "dependencies": {
                 "ms": {
                   "version": "0.7.1",
-                  "from": "ms@0.7.1",
+                  "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
                   "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
                 }
               }
             },
             "escape-html": {
               "version": "1.0.3",
-              "from": "escape-html@>=1.0.3 <1.1.0",
+              "from": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
               "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz"
             },
             "http-errors": {
               "version": "1.3.1",
-              "from": "http-errors@>=1.3.1 <1.4.0",
+              "from": "https://registry.npmjs.org/http-errors/-/http-errors-1.3.1.tgz",
               "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.3.1.tgz",
               "dependencies": {
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@>=2.0.1 <2.1.0",
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "statuses": {
                   "version": "1.2.1",
-                  "from": "statuses@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/statuses/-/statuses-1.2.1.tgz",
                   "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.2.1.tgz"
                 }
               }
             },
             "mime-types": {
               "version": "2.1.9",
-              "from": "mime-types@>=2.1.9 <2.2.0",
+              "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.9.tgz",
               "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.9.tgz",
               "dependencies": {
                 "mime-db": {
                   "version": "1.21.0",
-                  "from": "mime-db@>=1.21.0 <1.22.0",
+                  "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.21.0.tgz",
                   "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.21.0.tgz"
                 }
               }
             },
             "parseurl": {
               "version": "1.3.1",
-              "from": "parseurl@>=1.3.1 <1.4.0",
+              "from": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz",
               "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz"
             }
           }
         },
         "sockjs": {
           "version": "0.3.15",
-          "from": "sockjs@>=0.3.15 <0.4.0",
+          "from": "https://registry.npmjs.org/sockjs/-/sockjs-0.3.15.tgz",
           "resolved": "https://registry.npmjs.org/sockjs/-/sockjs-0.3.15.tgz",
           "dependencies": {
             "faye-websocket": {
               "version": "0.9.4",
-              "from": "faye-websocket@>=0.9.3 <0.10.0",
+              "from": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.9.4.tgz",
               "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.9.4.tgz",
               "dependencies": {
                 "websocket-driver": {
                   "version": "0.6.4",
-                  "from": "websocket-driver@>=0.5.1",
+                  "from": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.6.4.tgz",
                   "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.6.4.tgz",
                   "dependencies": {
                     "websocket-extensions": {
                       "version": "0.1.1",
-                      "from": "websocket-extensions@>=0.1.1",
+                      "from": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.1.tgz",
                       "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.1.tgz"
                     }
                   }
@@ -8150,53 +8174,53 @@
             },
             "node-uuid": {
               "version": "1.4.7",
-              "from": "node-uuid@>=1.4.1 <2.0.0",
+              "from": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz",
               "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz"
             }
           }
         },
         "sockjs-client": {
           "version": "1.0.3",
-          "from": "sockjs-client@>=1.0.3 <2.0.0",
+          "from": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.0.3.tgz",
           "resolved": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.0.3.tgz",
           "dependencies": {
             "debug": {
               "version": "2.2.0",
-              "from": "debug@>=2.1.0 <3.0.0",
+              "from": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
               "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
               "dependencies": {
                 "ms": {
                   "version": "0.7.1",
-                  "from": "ms@0.7.1",
+                  "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
                   "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
                 }
               }
             },
             "eventsource": {
               "version": "0.1.6",
-              "from": "eventsource@>=0.1.3 <0.2.0",
+              "from": "https://registry.npmjs.org/eventsource/-/eventsource-0.1.6.tgz",
               "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-0.1.6.tgz",
               "dependencies": {
                 "original": {
                   "version": "1.0.0",
-                  "from": "original@>=0.0.5",
+                  "from": "https://registry.npmjs.org/original/-/original-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/original/-/original-1.0.0.tgz"
                 }
               }
             },
             "faye-websocket": {
               "version": "0.7.3",
-              "from": "faye-websocket@>=0.7.3 <0.8.0",
+              "from": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.7.3.tgz",
               "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.7.3.tgz",
               "dependencies": {
                 "websocket-driver": {
                   "version": "0.6.4",
-                  "from": "websocket-driver@>=0.3.6",
+                  "from": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.6.4.tgz",
                   "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.6.4.tgz",
                   "dependencies": {
                     "websocket-extensions": {
                       "version": "0.1.1",
-                      "from": "websocket-extensions@>=0.1.1",
+                      "from": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.1.tgz",
                       "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.1.tgz"
                     }
                   }
@@ -8205,27 +8229,27 @@
             },
             "inherits": {
               "version": "2.0.1",
-              "from": "inherits@>=2.0.1 <3.0.0",
+              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             },
             "json3": {
               "version": "3.3.2",
-              "from": "json3@>=3.3.2 <4.0.0",
+              "from": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
               "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz"
             },
             "url-parse": {
               "version": "1.0.5",
-              "from": "url-parse@>=1.0.1 <2.0.0",
+              "from": "https://registry.npmjs.org/url-parse/-/url-parse-1.0.5.tgz",
               "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.0.5.tgz",
               "dependencies": {
                 "querystringify": {
                   "version": "0.0.3",
-                  "from": "querystringify@>=0.0.0 <0.1.0",
+                  "from": "https://registry.npmjs.org/querystringify/-/querystringify-0.0.3.tgz",
                   "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-0.0.3.tgz"
                 },
                 "requires-port": {
                   "version": "1.0.0",
-                  "from": "requires-port@>=1.0.0 <1.1.0",
+                  "from": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz"
                 }
               }
@@ -8234,73 +8258,73 @@
         },
         "stream-cache": {
           "version": "0.0.2",
-          "from": "stream-cache@>=0.0.1 <0.1.0",
+          "from": "https://registry.npmjs.org/stream-cache/-/stream-cache-0.0.2.tgz",
           "resolved": "https://registry.npmjs.org/stream-cache/-/stream-cache-0.0.2.tgz"
         },
         "strip-ansi": {
           "version": "3.0.0",
-          "from": "strip-ansi@>=3.0.0 <4.0.0",
+          "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
           "dependencies": {
             "ansi-regex": {
               "version": "2.0.0",
-              "from": "ansi-regex@>=2.0.0 <3.0.0",
+              "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
               "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
             }
           }
         },
         "supports-color": {
           "version": "3.1.2",
-          "from": "supports-color@>=3.1.1 <4.0.0",
+          "from": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
           "dependencies": {
             "has-flag": {
               "version": "1.0.0",
-              "from": "has-flag@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
             }
           }
         },
         "webpack-dev-middleware": {
           "version": "1.5.1",
-          "from": "webpack-dev-middleware@>=1.4.0 <2.0.0",
+          "from": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-1.5.1.tgz",
           "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-1.5.1.tgz",
           "dependencies": {
             "memory-fs": {
               "version": "0.3.0",
-              "from": "memory-fs@>=0.3.0 <0.4.0",
+              "from": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.3.0.tgz",
               "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.3.0.tgz",
               "dependencies": {
                 "errno": {
                   "version": "0.1.4",
-                  "from": "errno@>=0.1.3 <0.2.0",
+                  "from": "https://registry.npmjs.org/errno/-/errno-0.1.4.tgz",
                   "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.4.tgz",
                   "dependencies": {
                     "prr": {
                       "version": "0.0.0",
-                      "from": "prr@>=0.0.0 <0.1.0",
+                      "from": "https://registry.npmjs.org/prr/-/prr-0.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/prr/-/prr-0.0.0.tgz"
                     }
                   }
                 },
                 "readable-stream": {
                   "version": "2.0.5",
-                  "from": "readable-stream@>=2.0.1 <3.0.0",
+                  "from": "readable-stream@>=2.0.5 <2.1.0",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.2",
-                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@>=2.0.1 <2.1.0",
+                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     },
                     "isarray": {
                       "version": "0.0.1",
-                      "from": "isarray@0.0.1",
+                      "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                     },
                     "process-nextick-args": {
@@ -8310,7 +8334,7 @@
                     },
                     "string_decoder": {
                       "version": "0.10.31",
-                      "from": "string_decoder@>=0.10.0 <0.11.0",
+                      "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                     },
                     "util-deprecate": {
@@ -8324,7 +8348,7 @@
             },
             "mime": {
               "version": "1.3.4",
-              "from": "mime@>=1.3.4 <2.0.0",
+              "from": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
               "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz"
             }
           }
@@ -8333,7 +8357,7 @@
     },
     "webpack-stats-plugin": {
       "version": "0.1.1",
-      "from": "webpack-stats-plugin@>=0.1.1 <0.2.0",
+      "from": "https://registry.npmjs.org/webpack-stats-plugin/-/webpack-stats-plugin-0.1.1.tgz",
       "resolved": "https://registry.npmjs.org/webpack-stats-plugin/-/webpack-stats-plugin-0.1.1.tgz"
     }
   }

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "jsdom-global": "^1.5.0",
     "mocha": "^2.3.3",
     "react-addons-test-utils": "^0.14.2",
+    "react-hot-loader": "^1.3.0",
     "sinon": "^1.17.2"
   },
   "dependencies": {
@@ -48,7 +49,7 @@
     "redux-thunk": "~1.0.0",
     "sass-loader": "^3.1.1",
     "style-loader": "^0.13.0",
-    "webpack": "^1.12.3",
+    "webpack": "^1.12.13",
     "webpack-bundle-tracker": "0.0.8",
     "webpack-dev-server": "^1.12.1",
     "webpack-stats-plugin": "^0.1.1"

--- a/static/js/root.js
+++ b/static/js/root.js
@@ -1,4 +1,8 @@
 /* global StripeHandler:true, StripeCheckout:false, window:false, SETTINGS:false */
+if (process.env.NODE_ENV !== 'production') {
+  __webpack_public_path__ = `http://${SETTINGS.host}:8076/`;  // eslint-disable-line no-undef, camelcase
+}
+
 import React from 'react';
 import ReactDOM from 'react-dom';
 import '../sass/layout.scss';

--- a/webpack.config.dev.js
+++ b/webpack.config.dev.js
@@ -17,10 +17,7 @@ module.exports = {
       {
         test: /\.jsx?$/,
         exclude: /node_modules/,
-        loader: 'babel-loader',
-        query: {
-          presets: ['es2015', 'react']
-        }
+        loader: "react-hot!babel-loader?presets[]=es2015&presets[]=react",
       },  // to transform JSX into JS
       {
         test: /\.scss$/,


### PR DESCRIPTION
#### What are the relevant tickets?

Fixes #326
#### What's this PR do?

Adds hot reloading and upgrades to the version of webpack where `__webpack_public_path__` works for hot reloading.
#### Where should the reviewer start?

webpack.config.dev.js
#### How should this be manually tested?

Make a change that's visible from the browser and make sure that the change shows up properly, without a page refresh happening.
