### PR TITLE
Implemented popup of login after successful activation

### DIFF
--- a/static/js/actions/index_page.js
+++ b/static/js/actions/index_page.js
@@ -28,6 +28,7 @@ export const CLEAR_REGISTRATION_ERROR = 'CLEAR_REGISTRATION_ERROR';
 
 export const ACTIVATE_SUCCESS = 'ACTIVATE_SUCCESS';
 export const ACTIVATE_FAILURE = 'ACTIVATE_FAILURE';
+export const CLEAR_ACTIVATION = 'CLEAR_ACTIVATION';
 
 export const UPDATE_CART_ITEMS = 'UPDATE_CART_ITEMS';
 export const CLEAR_CART = 'CLEAR_CART';
@@ -58,7 +59,7 @@ export const receiveCourseListSuccess = createAction(
 
 const receiveCourseListFailure = createAction(RECEIVE_COURSE_LIST_FAILURE);
 
-export const showLogin = createAction(SHOW_LOGIN);
+export const showLogin = createAction(SHOW_LOGIN, message => ({message}));
 
 export const showSnackBar = createAction(SHOW_SNACKBAR);
 export const hideSnackBar = createAction(HIDE_SNACKBAR);
@@ -152,6 +153,7 @@ export function register(fullName, email, organization, password, redirect) {
 
 export const activateSuccess = createAction(ACTIVATE_SUCCESS);
 export const activateFailure = createAction(ACTIVATE_FAILURE);
+export const clearActivation = createAction(CLEAR_ACTIVATION);
 
 export function activate(token) {
   return dispatch => {

--- a/static/js/components/Header.js
+++ b/static/js/components/Header.js
@@ -38,6 +38,7 @@ class Header extends React.Component {
         reportRegisterError={error => dispatch(registerFailure(error))}
         loginError={authentication.error}
         registerError={registration.error}
+        message={loginModal.message}
       />
       </div>;
   }

--- a/static/js/components/LoginModal.js
+++ b/static/js/components/LoginModal.js
@@ -13,7 +13,13 @@ class LoginModal extends React.Component {
       isOpen,
       loginError,
       registerError,
+      message
     } = this.props;
+
+    let messageBox;
+    if (message !== undefined) {
+      messageBox = <div className="alert-message">{message}</div>;
+    }
 
     // Note that we don't store the password in the redux state to avoid
     // accidentally logging it via redux logger
@@ -21,7 +27,8 @@ class LoginModal extends React.Component {
       open={isOpen}
       onRequestClose={onHideLoginModal}>
       <div className="login-container">
-        <div ref="signin">
+        {messageBox}
+        <div ref="signin" className="login">
           <CardTitle
             title={"Sign In"}
           />
@@ -51,7 +58,7 @@ class LoginModal extends React.Component {
               onClick={onHideLoginModal}/>
           </div>
         </div>
-        <div ref="register">
+        <div ref="register" className="register">
           <CardTitle
             title={"Register"}
           />
@@ -130,7 +137,7 @@ class LoginModal extends React.Component {
     let organization = node.querySelector(".organization input").value;
     let password = node.querySelector(".password input").value;
     let confirmPassword = node.querySelector(".confirm-password input").value;
-    let redirect = window.location.toString();
+    let redirect = window.location.pathname + window.location.search + window.location.hash;
 
     if (email === "") {
       reportRegisterError("Email must not be blank");

--- a/static/js/containers/ActivatePage.js
+++ b/static/js/containers/ActivatePage.js
@@ -18,11 +18,11 @@ class ActivatePage extends React.Component {
   }
 
   componentWillReceiveProps(nextProps) {
-    const { location: { query } } = this.props;
+    const { history, location: { query } } = this.props;
 
     if (nextProps.activation.status === FETCH_SUCCESS &&
       this.props.activation.status !== nextProps.activation.status) {
-      window.location = query.redirect;
+      history.pushState(null, query.redirect);
     }
   }
 
@@ -51,6 +51,7 @@ class ActivatePage extends React.Component {
 ActivatePage.propTypes = {
   location: React.PropTypes.object.isRequired,
   dispatch: React.PropTypes.func.isRequired,
+  history: React.PropTypes.object.isRequired,
   activation: React.PropTypes.object.isRequired
 };
 

--- a/static/js/containers/App.js
+++ b/static/js/containers/App.js
@@ -8,6 +8,8 @@ import { connect } from 'react-redux';
 import {
   showSnackBar,
   hideSnackBar,
+  clearActivation,
+  showLogin,
   FETCH_FAILURE,
   FETCH_SUCCESS,
 } from '../actions/index_page';
@@ -16,10 +18,12 @@ class App extends React.Component {
 
   componentDidMount() {
     this.handleMessage.call(this);
+    this.showLoginAfterActivation.call(this);
   }
 
   componentDidUpdate() {
     this.handleMessage.call(this);
+    this.showLoginAfterActivation.call(this);
   }
 
   handleMessage() {
@@ -40,6 +44,14 @@ class App extends React.Component {
     // If message is already displayed don't display it again to avoid recursion
     if (message !== undefined && message !== snackBar.message) {
       dispatch(showSnackBar({message: message}));
+    }
+  }
+
+  showLoginAfterActivation() {
+    const { dispatch, activation } = this.props;
+    if (activation.status === FETCH_SUCCESS) {
+      dispatch(clearActivation());
+      dispatch(showLogin("Thanks for activating! You may now sign in."));
     }
   }
 
@@ -87,6 +99,7 @@ App.propTypes = {
 
 const mapStateToProps = (state) => {
   return {
+    activation: state.activation,
     authentication: state.authentication,
     registration: state.registration,
     loginModal: state.loginModal,

--- a/static/js/reducers/index_page.js
+++ b/static/js/reducers/index_page.js
@@ -24,6 +24,7 @@ import {
   ACTIVATE_SUCCESS,
   ACTIVATE_FAILURE,
   ACTIVATE,
+  CLEAR_ACTIVATION,
   CLEAR_CART,
   CLEAR_INVALID_CART_ITEMS,
   UPDATE_CART_ITEMS,
@@ -99,10 +100,11 @@ export const course = handleActions({
   CLEAR_COURSE: (state, action) => INITIAL_COURSE_STATE
 }, INITIAL_COURSE_STATE);
 
+const INITIAL_LOGIN = {visible: false};
 export const loginModal = handleActions({
-  SHOW_LOGIN: () => ({ visible: true }),
+  SHOW_LOGIN: (state, action) => ({ visible: true, message: action.payload.message }),
   HIDE_LOGIN: () => ({ visible: false })
-}, {visible: false});
+}, INITIAL_LOGIN);
 
 export const authentication = handleActions({
   LOGIN_FAILURE: (state, action) => ({
@@ -139,10 +141,12 @@ export const registration = handleActions({
   CLEAR_REGISTRATION_ERROR: payloadMerge((action) => ({error: ""}))
 }, { error: "", status: null });
 
+const INITIAL_ACTIVATION_STATUS = { status: null };
 export const activation = handleActions({
   ACTIVATE_SUCCESS: () => ({ status: FETCH_SUCCESS }),
-  ACTIVATE_FAILURE: () => ({ status: FETCH_FAILURE })
-}, { status: null });
+  ACTIVATE_FAILURE: () => ({ status: FETCH_FAILURE }),
+  CLEAR_ACTIVATION: () => INITIAL_ACTIVATION_STATUS
+}, INITIAL_ACTIVATION_STATUS);
 
 export const cart = handleActions({
   RECEIVE_COURSE_LIST_SUCCESS: payloadMerge((action) => ({

--- a/static/js/reducers/index_test.js
+++ b/static/js/reducers/index_test.js
@@ -9,6 +9,7 @@ import {
   login,
   register,
   activate,
+  clearActivation,
   checkout,
   checkoutSuccess,
   checkoutFailure,
@@ -45,6 +46,7 @@ import {
   REGISTER_FAILURE,
   ACTIVATE_SUCCESS,
   ACTIVATE_FAILURE,
+  CLEAR_ACTIVATION,
   UPDATE_CART_ITEMS,
   UPDATE_CART_VISIBILITY,
   UPDATE_SEAT_COUNT,
@@ -157,9 +159,10 @@ describe('reducers', () => {
     });
 
     it('should set login state to show when triggered', done => {
-      dispatchThen(showLogin(), [SHOW_LOGIN]).then(state => {
+      dispatchThen(showLogin("message"), [SHOW_LOGIN]).then(state => {
         assert.deepEqual(state, {
-          visible: true
+          visible: true,
+          message: "message"
         });
         done();
       });
@@ -406,6 +409,18 @@ describe('reducers', () => {
       dispatchThen(activate("token"), [ACTIVATE_FAILURE]).then(activationState => {
         assert.deepEqual(activationState, {
           status: FETCH_FAILURE
+        });
+
+        done();
+      });
+    });
+
+    it('clears activation status', done => {
+      store.dispatch({type: ACTIVATE_SUCCESS});
+
+      dispatchThen(clearActivation(), [CLEAR_ACTIVATION]).then(activationState => {
+        assert.deepEqual(activationState, {
+          status: null
         });
 
         done();

--- a/static/sass/layout.scss
+++ b/static/sass/layout.scss
@@ -361,7 +361,12 @@ h3.course-listing-header {
 .login-container {
   @include outer-container;
   @include pad($block-padding);
-  > div {
+  .login {
+    @include span-columns(6);
+    display: inline-block;
+  }
+
+  .register {
     @include span-columns(6);
     display: inline-block;
   }
@@ -403,4 +408,12 @@ h3.course-listing-header {
     margin-right: 30px;
     margin-top: 20px;
   }
+}
+
+.alert-message {
+  background-color: #d9edf7;
+  padding: 15px;
+  margin-bottom: 20px;
+  border: 1px solid #bce8f1;
+  border-radius: 4px;
 }


### PR DESCRIPTION
#### What are the relevant tickets?

Fixes #329 
Fixes #353
#### What's this PR do?
- Changes ActivatePage to change location using browser history instead of window.location (required for other changes)
- Change redirect URL to be a relative path, required for using the browser history
- Add message box to login modal
- After activation, the user will be redirected to somewhere in the app, and they will see a login dialog with a success message. They should not see the message any other time after the login dialog closes.
#### Where should the reviewer start?

App.js, in showLoginAfterActivation()
#### How should this be manually tested?
- Register a new user
- Click the activation link (this will be in the web console)
- See the login pop up automatically
#### Screenshots (if appropriate)

![screenshot from 2016-02-17 17 35 39](https://cloud.githubusercontent.com/assets/863262/13127351/e332f0a4-d59c-11e5-83d2-dcc3ae20c3e8.png)
