### PR TITLE
Changed seat count to textbox, changed slider's step to 1

### DIFF
--- a/static/js/components/BuyTab.js
+++ b/static/js/components/BuyTab.js
@@ -10,6 +10,8 @@ import ChapterTab from './ChapterTab';
 import StripeButton from './StripeButton';
 import { getModule, getCourse, calculateTotal } from '../util/util';
 
+const MAX_SEATS = 200;
+
 class BuyTab extends React.Component {
   componentWillReceiveProps(nextProps) {
     // Workaround for half baked LeftNav material-ui component
@@ -33,6 +35,7 @@ class BuyTab extends React.Component {
       buyTab,
       buyTabTotal,
       updateSelectedChapters,
+      updateSeatCount,
       } = this.props;
 
     let cartContents = <MenuItem>No chapters selected</MenuItem>;
@@ -52,7 +55,6 @@ class BuyTab extends React.Component {
       });
     }
 
-    const maxSeats = 200;
     let cartTotal = calculateTotal(cart.cart, courseList);
 
     return <div className="course-purchase-selector">
@@ -62,22 +64,35 @@ class BuyTab extends React.Component {
           <Slider
             className="number-of-seats"
             name="number-of-seats"
-            max={maxSeats}
+            max={MAX_SEATS}
             value={buyTab.seats}
-            step={10}
+            step={1}
             style={{ 'marginBottom': '5px' }}
-            onChange={this.onUpdateSeatCount.bind(this)}
+            onChange={(e, value) => this.onUpdateSeatCount.call(this, value)}
           />
           <div className="slider-scale">
             <span className="left">0</span>
-            <span className="left-quarter">{maxSeats * 0.25}</span>
-            <span className="middle">{maxSeats * 0.5}</span>
-            <span className="right-quarter">{maxSeats * 0.75}</span>
-            <span className="right">{maxSeats}</span>
+            <span className="left-quarter">{MAX_SEATS * 0.25}</span>
+            <span className="middle">{MAX_SEATS * 0.5}</span>
+            <span className="right-quarter">{MAX_SEATS * 0.75}</span>
+            <span className="right">{MAX_SEATS}</span>
           </div>
         </div>
-        <div className="seatCount">{buyTab.seats}<br /><span className="seatCountLabel">Seats</span></div>
-        <div className="selectionTotal">${buyTabTotal}<br /><span className="selectionTotalLabel">Total</span></div>
+        <div className="seat-count">
+          <input
+            type="text"
+            value={buyTab.seats}
+            onChange={e => this.onUpdateSeatCount.call(this, e.target.value)}
+            className="seat-count-text"
+          />
+          <br />
+          <span className="seat-count-label">Seats</span>
+        </div>
+        <div className="selection-total">
+          ${buyTabTotal}
+          <br />
+          <span className="selection-total-label">Total</span>
+        </div>
         <RaisedButton
           label="Update Cart"
           className="add-to-cart"
@@ -87,7 +102,7 @@ class BuyTab extends React.Component {
       </div>
       <h3 className="chapter-label">Chapters</h3>
       <ChapterTab
-        className="moduleSelector"
+        className="module-selector"
         selectable={selectable}
         multiSelectable={selectable}
         enableSelectAll={selectable}
@@ -137,9 +152,20 @@ class BuyTab extends React.Component {
     updateCartVisibility(true);
   }
 
-  onUpdateSeatCount(e, value) {
+  onUpdateSeatCount(value) {
     const { updateSeatCount } = this.props;
-    updateSeatCount(value);
+
+    let number = parseInt(value);
+    if (!isFinite(number)) {
+      number = 0;
+    }
+    if (number < 0) {
+      number = 0;
+    }
+    if (number > MAX_SEATS) {
+      number = MAX_SEATS;
+    }
+    updateSeatCount(number);
   }
 
   onCartClose() {

--- a/static/sass/layout.scss
+++ b/static/sass/layout.scss
@@ -270,24 +270,31 @@ h3.course-listing-header {
           text-align: right;
         }
       }
-      .seatCount {
+      .seat-count {
         @include span-columns(2);
+
         font-size: 2em;
         text-align: center;
         font-weight: 700;
+        .seat-count-text {
+          font-size: 1em;
+          text-align: center;
+          font-weight: 700;
+          width: 100px;
+        }
 
-        .seatCountLabel {
+        .seat-count-label {
           font-size: 0.5em;
           text-align: center;
         }
       }
-      .selectionTotal {
+      .selection-total {
         @include span-columns(2);
         color: green;
         font-size: 2em;
         font-weight: 700;
         text-align: center;
-        .selectionTotalLabel {
+        .selection-total-label {
           font-size: 0.5em;
           text-align: center;
         }
@@ -302,7 +309,7 @@ h3.course-listing-header {
       font-size: 1.5em;
       text-align: left;
     }
-    .moduleSelector {
+    .module-selector {
       @include clearfix;
     }
   }


### PR DESCRIPTION
#### What are the relevant tickets?

Fixes #290 
#### What's this PR do?
- Changes the seat count to be a textbox
- Changes the slider to move by increment of one
- Also renames some CSS classes for consistency
#### Where should the reviewer start?

static/js/components/BuyTab.js
#### How should this be manually tested?

As a logged in user go to the course detail page, click the Buy tab, then move the slider around. Also edit the number in the textbox. If you try numbers outside the range of 0 and 200 it should cap the number inside the range. Invalid input like letters should be changed to 0. 
#### Screenshots (if appropriate)

![screenshot from 2016-02-19 17 42 00](https://cloud.githubusercontent.com/assets/863262/13191204/19fe7448-d730-11e5-8209-2532b1763cd0.png)
#### What GIF best describes this PR or how it makes you feel?

![](https://lh3.googleusercontent.com/-l4giPIz1ZLY/U1-MRAPT__I/AAAAAAAAJKU/OKvQBb6tCzY/w426-h292/slider.gif)
