### PR TITLE
Removed check that required a cart to contain all modules for a course

### DIFF
--- a/portal/util.py
+++ b/portal/util.py
@@ -163,12 +163,6 @@ def validate_cart(cart, user):
 
             modules_in_cart.add(uuid)
 
-    for module_uuid in modules_in_cart:
-        module = Module.objects.get(uuid=module_uuid)
-        uuids = module.course.module_set.values_list('uuid', flat=True)
-        if not modules_in_cart.issuperset(uuids):
-            raise ValidationError("You must purchase all modules for a course.")
-
 
 def create_order(cart, user):
     """

--- a/portal/util_test.py
+++ b/portal/util_test.py
@@ -344,31 +344,6 @@ class CheckoutValidationTests(CourseTests):
             ], self.user)
         assert ex.exception.detail[0] == "Course does not match up with module"
 
-    def test_must_have_all_children_in_cart(self):  # pylint: disable=invalid-name
-        """
-        If user tries to buy a subset of a course, raise a validation error.
-
-        Note: It's expected that this will be removed when we support buying
-        modules.
-        """
-        # Create second module so we need to pass both modules to the API to purchase
-        ModuleFactory.create(
-            course=self.course,
-            title='test',
-            price_without_tax=100
-        )
-
-        with self.assertRaises(ValidationError) as ex:
-            validate_cart([
-                {
-                    'uuids': [self.module.uuid],
-                    'seats': 5,
-                    'course_uuid': self.course.uuid
-                },
-            ], self.user)
-
-        assert ex.exception.detail[0] == 'You must purchase all modules for a course.'
-
     def test_dont_allow_empty_uuids(self):
         """
         Raise a ValidationError if uuids list is empty


### PR DESCRIPTION
#### What are the relevant tickets?

Fixes #217 
#### What's this PR do?

Removes the restriction requiring entire courses to be purchased at once
#### How should this be manually tested?

You should be able to purchase a single module of a CCX successfully
