### PR TITLE
Fixed scroll after checkout

### DIFF
--- a/static/js/root.js
+++ b/static/js/root.js
@@ -1,4 +1,5 @@
-/* global StripeHandler:true, StripeCheckout:false, window:false, SETTINGS:false */
+/* global StripeHandler:true, StripeCheckout:false, window:false, SETTINGS:false,
+   document: false */
 if (process.env.NODE_ENV !== 'production') {
   __webpack_public_path__ = `http://${SETTINGS.host}:8076/`;  // eslint-disable-line no-undef, camelcase
 }
@@ -39,6 +40,13 @@ StripeHandler = StripeCheckout.configure({
       store.getState().course.courseList
     );
     store.dispatch(checkout(store.getState().cart.cart, token.id, total));
+  },
+  closed: () => {
+    // Fix body style CSS. When the slider opens material-ui adds a 'overflow: hidden'
+    // but Stripe checkout will add a 'position: relative'. The slider closes as Stripe
+    // checkout opens so Stripe checkout thinks the state it wants to preserve is 'overflow: hidden'
+    // but that breaks scrolling
+    document.body.style = "";
   }
 });
 


### PR DESCRIPTION
#### What are the relevant tickets?

Fixes #397 
#### What's this PR do?

When the slider opens material-ui adds `overflow: hidden` to the `style` of `<body>`. It will take it away after the slider closes, but we open Stripe checkout during this process and Stripe thinks that `overflow: hidden` is the original state of `<body>`. So when the stripe checkout box goes away it adds this style back to `<body>` which breaks scrolling.
#### How should this be manually tested?

Go through the checkout flow, then try to scroll the page with the mouse wheel.
