### PR TITLE
If there's a missing userinfo, error rather than 500

### DIFF
--- a/portal/views/activation.py
+++ b/portal/views/activation.py
@@ -38,7 +38,7 @@ def activate_view(request):
     try:
         userinfo = UserInfo.objects.get(registration_token=token)
     except UserInfo.DoesNotExist:
-        return Response(status=403)
+        return Response("Could not find registration token.", status=403)
 
     user = userinfo.user
     user.is_active = True

--- a/portal/views/checkout_api.py
+++ b/portal/views/checkout_api.py
@@ -8,6 +8,7 @@ from decimal import Decimal
 
 from django.conf import settings
 from django.db import transaction
+from django.core.exceptions import ObjectDoesNotExist
 from rest_framework.exceptions import ValidationError
 from rest_framework.response import Response
 from rest_framework.views import APIView
@@ -46,6 +47,11 @@ class CheckoutView(APIView):
         """
         errors = set()
         courses_and_seats = {}
+
+        try:
+            user.userinfo
+        except ObjectDoesNotExist:
+            raise ValidationError("You must have a user profile to check out.")
 
         # OrderLine stores a reference to a module and the number of seats
         # for each module. This number of seats should always be the same for each module

--- a/portal/views/login.py
+++ b/portal/views/login.py
@@ -3,6 +3,7 @@ Views for login/logout.
 """
 from __future__ import unicode_literals
 
+from django.core.exceptions import ObjectDoesNotExist
 from django.contrib.auth import authenticate, login, logout
 from rest_framework.decorators import api_view, permission_classes
 from rest_framework.response import Response
@@ -39,11 +40,17 @@ class LoginView(APIView):
             username=username,
             password=password,
         )
+
         if user is not None:
+            full_name = user.email
+            try:
+                full_name = user.userinfo.full_name
+            except (ObjectDoesNotExist,):
+                pass
             if user.is_active:
                 login(request, user)
                 return Response(status=200, data={
-                    'name': user.userinfo.full_name,
+                    'name': full_name,
                 })
             else:
                 return Response(status=403)

--- a/portal/views/login_test.py
+++ b/portal/views/login_test.py
@@ -40,6 +40,21 @@ class LoginTests(AuthenticationTestCase):
         assert self.is_authenticated(self.user)
         assert not self.is_authenticated(self.other_user)
 
+    def test_login_success_no_userinfo(self):
+        """If the user has no userinfo object, their name is the email"""
+        UserInfo.objects.filter(user=self.user).delete()
+        resp = self.client.post(
+            reverse('login'),
+            json.dumps({
+                "username": self.USERNAME,
+                "password": self.PASSWORD,
+            }),
+            content_type="application/json"
+        )
+        assert resp.status_code == 200, resp.content.decode('utf-8')
+        json_data = json.loads(resp.content.decode('utf-8'))
+        assert json_data['name'] == self.user.email
+
     def test_login_twice(self):
         """
         User logs in in while already logged in

--- a/portal/views/webpack.py
+++ b/portal/views/webpack.py
@@ -21,14 +21,18 @@ def index_view(request):
         HttpResponse
     """
     host = request.get_host().split(":")[0]
-    try:
+
+    # AnonymousUser doesn't have an email address
+    email = ""
+    # Incorrectly built/anonymous users lack a userinfo property.
+    name = ""
+    if not request.user.is_anonymous():
         email = request.user.email
-        name = request.user.userinfo.full_name
-    except (AttributeError, ObjectDoesNotExist):
-        # AnonymousUser doesn't have an email address
-        # or incorrectly built user, as it lacks a userinfo property.
-        email = ""
-        name = ""
+
+        try:
+            name = request.user.userinfo.full_name
+        except (ObjectDoesNotExist,):
+            pass
 
     js_settings = {
         "host": host,

--- a/portal/views/webpack_test.py
+++ b/portal/views/webpack_test.py
@@ -33,6 +33,24 @@ class TestViews(TestCase):
                     status_code=200
                 )
 
+    def test_no_userinfo_still_email(self):
+        """
+        If there is no userinfo object, it should still show the email.
+        """
+        User.objects.create_user(
+            username='user',
+            password='pass',
+            email='darth@vad.er',
+        )
+        assert self.client.login(username='user', password='pass')
+
+        response = self.client.get(reverse('portal-index'))
+        self.assertContains(
+            response,
+            '''email": "darth@vad.er"''',
+            msg_prefix=response.content.decode('utf-8')
+        )
+
     def test_empty_name_no_user(self):
         """
         If there is no userinfo object, it should still render the homepage


### PR DESCRIPTION
#### What are the relevant tickets?

Fixes #406 
#### What's this PR do?

Wraps guards around times we expect to have userinfo objects and raises a validation error if it doesn't.
#### Where should the reviewer start?

checkout.py
#### How should this be manually tested?

Create a superuser. Go do TP things (view courses, etc) and you shouldn't get 500s.
#### Any background context you want to provide?
#### Screenshots (if appropriate)
#### What GIF best describes this PR or how it makes you feel?

![](http://s.mlkshk-cdn.com/r/17RCM.jpg)
