### PR TITLE
Fixed snackbar behavior

### DIFF
--- a/static/js/actions/index_page.js
+++ b/static/js/actions/index_page.js
@@ -9,22 +9,18 @@ export const RECEIVE_COURSE_FAILURE = 'RECEIVE_COURSE_FAILURE';
 export const REQUEST_COURSE_LIST = 'REQUEST_COURSE_LIST';
 export const RECEIVE_COURSE_LIST_SUCCESS = 'RECEIVE_COURSE_LIST_SUCCESS';
 export const RECEIVE_COURSE_LIST_FAILURE = 'RECEIVE_COURSE_LIST_FAILURE';
-export const CLEAR_COURSE = 'CLEAR_COURSE';
 
 export const SHOW_LOGIN = 'SHOW_LOGIN';
 export const HIDE_LOGIN = 'HIDE_LOGIN';
 
-export const SHOW_SNACKBAR = 'SHOW_SNACKBAR';
 export const HIDE_SNACKBAR = 'HIDE_SNACKBAR';
 
 export const LOGIN_FAILURE = 'LOGIN_FAILURE';
 export const LOGIN_SUCCESS = 'LOGIN_SUCCESS';
 export const LOGOUT = 'LOGOUT';
-export const CLEAR_AUTHENTICATION_ERROR = 'CLEAR_AUTHENTICATION_ERROR';
 
 export const REGISTER_SUCCESS = 'REGISTER_SUCCESS';
 export const REGISTER_FAILURE = 'REGISTER_FAILURE';
-export const CLEAR_REGISTRATION_ERROR = 'CLEAR_REGISTRATION_ERROR';
 
 export const ACTIVATE_SUCCESS = 'ACTIVATE_SUCCESS';
 export const ACTIVATE_FAILURE = 'ACTIVATE_FAILURE';
@@ -48,33 +44,22 @@ export const FETCH_SUCCESS = 'FETCH_SUCCESS';
 export const FETCH_PROCESSING = 'FETCH_PROCESSING';
 
 const requestCourse = createAction(REQUEST_COURSE);
-
 export const receiveCourseSuccess = createAction(
   RECEIVE_COURSE_SUCCESS, (course) => {return {course};});
-
-const receiveCourseFailure = createAction(RECEIVE_COURSE_FAILURE);
+export const receiveCourseFailure = createAction(RECEIVE_COURSE_FAILURE);
 const requestCourseList = createAction(REQUEST_COURSE_LIST);
-
 export const receiveCourseListSuccess = createAction(
   RECEIVE_COURSE_LIST_SUCCESS, (courseList) => {return {courseList};});
-
-const receiveCourseListFailure = createAction(RECEIVE_COURSE_LIST_FAILURE);
+export const receiveCourseListFailure = createAction(RECEIVE_COURSE_LIST_FAILURE);
 
 export const showLogin = createAction(SHOW_LOGIN, message => ({message}));
 
-export const showSnackBar = createAction(SHOW_SNACKBAR);
 export const hideSnackBar = createAction(HIDE_SNACKBAR);
 
 export function hideLogin() {
   return dispatch => {
     dispatch({
       type: HIDE_LOGIN
-    });
-    dispatch({
-      type: CLEAR_AUTHENTICATION_ERROR
-    });
-    dispatch({
-      type: CLEAR_REGISTRATION_ERROR
     });
   };
 }
@@ -110,9 +95,6 @@ export function logout() {
       dispatch({
         type: LOGOUT
       });
-      dispatch({
-        type: CLEAR_COURSE
-      });
     });
   };
 }
@@ -121,9 +103,6 @@ export function login(username, password) {
   return dispatch => {
     return api.login(username, password).
       then((data) => {
-        dispatch({
-          type: CLEAR_COURSE
-        });
         return dispatch(loginSuccess(data));
       }).
       catch((e) => {

--- a/static/js/containers/ActivatePage.js
+++ b/static/js/containers/ActivatePage.js
@@ -6,7 +6,6 @@ import {
   FETCH_PROCESSING,
   FETCH_FAILURE,
   activate,
-  showSnackBar
 } from '../actions/index_page';
 
 class ActivatePage extends React.Component {

--- a/static/js/containers/App.js
+++ b/static/js/containers/App.js
@@ -6,7 +6,6 @@ import RaisedButton from 'material-ui/lib/raised-button';
 import { connect } from 'react-redux';
 
 import {
-  showSnackBar,
   hideSnackBar,
   clearActivation,
   showLogin,
@@ -17,34 +16,11 @@ import {
 class App extends React.Component {
 
   componentDidMount() {
-    this.handleMessage.call(this);
     this.showLoginAfterActivation.call(this);
   }
 
   componentDidUpdate() {
-    this.handleMessage.call(this);
     this.showLoginAfterActivation.call(this);
-  }
-
-  handleMessage() {
-    const {
-      registration,
-      dispatch,
-      snackBar
-    } = this.props;
-
-    let message;
-
-    if (registration.status === FETCH_FAILURE) {
-      message = "An error occurred registering the user.";
-    } else if (registration.status === FETCH_SUCCESS) {
-      message = "User registered successfully! Check your email for an activation link.";
-    }
-
-    // If message is already displayed don't display it again to avoid recursion
-    if (message !== undefined && message !== snackBar.message) {
-      dispatch(showSnackBar({message: message}));
-    }
   }
 
   showLoginAfterActivation() {

--- a/static/js/containers/CourseDetailPage.js
+++ b/static/js/containers/CourseDetailPage.js
@@ -6,7 +6,6 @@ import {
   fetchCourse,
   fetchCourseList,
   clearInvalidCartItems,
-  showSnackBar,
   FETCH_FAILURE,
   FETCH_SUCCESS
 } from '../actions/index_page';
@@ -16,12 +15,10 @@ class CourseDetailPage extends React.Component {
 
   componentDidMount() {
     this.fetchCourse.call(this, true);
-    this.handleError.call(this);
   }
 
   componentDidUpdate() {
     this.fetchCourse.call(this);
-    this.handleError.call(this);
   }
 
   // forceFetchCourse will trigger a fetch of the course, regardless
@@ -29,7 +26,6 @@ class CourseDetailPage extends React.Component {
   fetchCourse(forceFetchCourse = false) {
     const {
       course,
-      authentication,
       dispatch,
       params: { uuid }
     } = this.props;
@@ -76,27 +72,12 @@ class CourseDetailPage extends React.Component {
       </div>
       ;
   }
-
-
-  handleError() {
-    const { course, dispatch } = this.props;
-
-    let error;
-
-    if (course.courseStatus === FETCH_FAILURE) {
-      error = "An error occurred fetching information about this course.";
-    } else if (course.courseListStatus === FETCH_FAILURE) {
-      error = "An error occurred fetching information about other courses.";
-    }
-    if (error) {
-      dispatch(showSnackBar({ message: error }));
-    }
-  }
 }
 
 CourseDetailPage.propTypes = {
   course: React.PropTypes.object.isRequired,
   authentication: React.PropTypes.object.isRequired,
+  snackBar: React.PropTypes.object.isRequired,
   dispatch: React.PropTypes.func.isRequired,
   params: React.PropTypes.object.isRequired
 };
@@ -104,7 +85,8 @@ CourseDetailPage.propTypes = {
 const mapStateToProps = (state) => {
   return {
     course: state.course,
-    authentication: state.authentication
+    authentication: state.authentication,
+    snackBar: state.snackBar
   };
 };
 

--- a/static/js/containers/CourseDetailPage_test.js
+++ b/static/js/containers/CourseDetailPage_test.js
@@ -16,17 +16,19 @@ import { calculateTotal } from '../util/util';
 import {
   receiveCourseListSuccess,
   receiveCourseSuccess,
+  receiveCourseListFailure,
+  receiveCourseFailure,
   loginSuccess,
   updateSeatCount,
   updateSelectedChapters,
   checkout,
   updateCartItems,
+  registerSuccess,
+  registerFailure,
 
   SHOW_LOGIN,
   HIDE_LOGIN,
   LOGIN_SUCCESS,
-  CLEAR_AUTHENTICATION_ERROR,
-  CLEAR_REGISTRATION_ERROR,
   REQUEST_COURSE,
   REQUEST_COURSE_LIST,
   RECEIVE_COURSE_SUCCESS,
@@ -42,11 +44,14 @@ import {
 } from '../actions/index_page';
 
 describe('CourseDetailPage', () => {
-  let store, sandbox, container, checkoutStub, listenForActions, dispatchThen;
+  let store, sandbox, container, checkoutStub, courseStub, listenForActions, dispatchThen;
 
   beforeEach(() => {
     sandbox = sinon.sandbox.create();
     checkoutStub = sandbox.stub(api, 'checkout');
+
+    courseStub = sandbox.stub(api, 'getCourse');
+    courseStub.returns(Promise.resolve(COURSE_RESPONSE1));
 
     store = configureTestStore();
     listenForActions = store.createListenForActions(state => state);
@@ -109,9 +114,6 @@ describe('CourseDetailPage', () => {
   });
 
   it('can check off items in the buy tab', done => {
-    let courseStub = sandbox.stub(api, 'getCourse');
-    courseStub.returns(Promise.resolve(COURSE_RESPONSE1));
-
     // Set up state as if we logged in already
     store.dispatch(loginSuccess({name: "Darth Vader"}));
     store.dispatch(receiveCourseListSuccess(COURSE_LIST));
@@ -149,7 +151,6 @@ describe('CourseDetailPage', () => {
   });
 
   it('can add items to the cart', done => {
-    let courseStub = sandbox.stub(api, 'getCourse');
     courseStub.returns(Promise.resolve(COURSE_RESPONSE2));
     // Alter state as if we logged in, selected all chapters and updated seat count
     const course1SeatCount = 77;
@@ -205,9 +206,6 @@ describe('CourseDetailPage', () => {
   });
 
   it('shows items in the cart panel', done => {
-    let courseStub = sandbox.stub(api, 'getCourse');
-    courseStub.returns(Promise.resolve(COURSE_RESPONSE1));
-
     const course1SeatCount = 77;
     const course2SeatCount = 88;
     const coursePairs = [{
@@ -265,9 +263,6 @@ describe('CourseDetailPage', () => {
   });
 
   it('can checkout the cart', done => {
-    let courseStub = sandbox.stub(api, 'getCourse');
-    courseStub.returns(Promise.resolve(COURSE_RESPONSE1));
-
     const fakeToken = "FAKE_TOKEN";
 
     const course1SeatCount = 77;
@@ -335,9 +330,6 @@ describe('CourseDetailPage', () => {
   });
 
   it('can checkout the cart with an empty price', done => {
-    let courseStub = sandbox.stub(api, 'getCourse');
-    courseStub.returns(Promise.resolve(COURSE_RESPONSE1));
-
     const zeroPriceCourse = Object.assign(COURSE_RESPONSE1,
       {
         modules: COURSE_RESPONSE1.modules.map(child =>
@@ -381,9 +373,6 @@ describe('CourseDetailPage', () => {
   });
 
   it('fails to checkout', done => {
-    let courseStub = sandbox.stub(api, 'getCourse');
-    courseStub.returns(Promise.resolve(COURSE_RESPONSE1));
-
     const zeroPriceCourse = Object.assign(COURSE_RESPONSE1,
       {
         modules: COURSE_RESPONSE1.modules.map(child =>

--- a/static/js/reducers/index_page.js
+++ b/static/js/reducers/index_page.js
@@ -6,10 +6,8 @@ import {
   RECEIVE_COURSE_LIST_SUCCESS,
   RECEIVE_COURSE_LIST_FAILURE,
   REQUEST_COURSE_LIST,
-  CLEAR_COURSE,
   SHOW_LOGIN,
   HIDE_LOGIN,
-  SHOW_SNACKBAR,
   HIDE_SNACKBAR,
   FETCH_FAILURE,
   FETCH_PROCESSING,
@@ -17,8 +15,6 @@ import {
   LOGIN_FAILURE,
   LOGIN_SUCCESS,
   LOGOUT,
-  CLEAR_AUTHENTICATION_ERROR,
-  CLEAR_REGISTRATION_ERROR,
   REGISTER_SUCCESS,
   REGISTER_FAILURE,
   ACTIVATE_SUCCESS,
@@ -52,10 +48,6 @@ const INITIAL_SNACKBAR_STATE = {
 };
 
 export const snackBar = handleActions({
-  SHOW_SNACKBAR: payloadMerge((action) => ({
-    message: action.payload.message,
-    open: true
-  })),
   HIDE_SNACKBAR: payloadMerge((action) => ({
     open: false
   })),
@@ -65,6 +57,22 @@ export const snackBar = handleActions({
   })),
   CHECKOUT_FAILURE: payloadMerge(action => ({
     message: "There was an error purchasing the course.",
+    open: true
+  })),
+  RECEIVE_COURSE_FAILURE: payloadMerge(() => ({
+    message: "An error occurred fetching information about this course.",
+    open: true
+  })),
+  RECEIVE_COURSE_LIST_FAILURE: payloadMerge(() => ({
+    message: "An error occurred fetching information about other courses.",
+    open: true
+  })),
+  REGISTER_SUCCESS: payloadMerge(() => ({
+    message: "User registered successfully! Check your email for an activation link.",
+    open: true
+  })),
+  REGISTER_FAILURE: payloadMerge(() => ({
+    message: "An error occurred registering the user.",
     open: true
   }))
 }, INITIAL_SNACKBAR_STATE);
@@ -100,7 +108,8 @@ export const course = handleActions({
     courseListStatus: FETCH_FAILURE
   })),
 
-  CLEAR_COURSE: (state, action) => INITIAL_COURSE_STATE
+  LOGIN_SUCCESS: (state, action) => INITIAL_COURSE_STATE,
+  LOGOUT: (state, action) => INITIAL_COURSE_STATE
 }, INITIAL_COURSE_STATE);
 
 const INITIAL_LOGIN = {visible: false};
@@ -125,13 +134,17 @@ export const authentication = handleActions({
     isAuthenticated: false,
     name: ""
   }),
-  CLEAR_AUTHENTICATION_ERROR: payloadMerge((action) => ({error: ""}))
+  HIDE_LOGIN: payloadMerge((action) => ({error: ""}))
 }, {
   isAuthenticated: SETTINGS.isAuthenticated,
   name: SETTINGS.name,
   error: ""
 });
 
+const INITIAL_REGISTRATION = {
+  error: "",
+  status: null
+};
 export const registration = handleActions({
   REGISTER_SUCCESS: (state, action) => ({
     error: "",
@@ -141,8 +154,8 @@ export const registration = handleActions({
     error: action.payload.error,
     status: FETCH_FAILURE
   }),
-  CLEAR_REGISTRATION_ERROR: payloadMerge((action) => ({error: ""}))
-}, { error: "", status: null });
+  HIDE_LOGIN: payloadMerge((action) => ({error: ""}))
+}, INITIAL_REGISTRATION);
 
 const INITIAL_ACTIVATION_STATUS = { status: null };
 export const activation = handleActions({

--- a/static/js/reducers/index_test.js
+++ b/static/js/reducers/index_test.js
@@ -1,7 +1,6 @@
 import {
   showLogin,
   hideLogin,
-  showSnackBar,
   hideSnackBar,
   logout,
   loginFailure,
@@ -21,6 +20,10 @@ import {
   updateSelectedChapters,
   clearInvalidCartItems,
   receiveCourseListSuccess,
+  receiveCourseListFailure,
+  receiveCourseFailure,
+  registerSuccess,
+  registerFailure,
   removeCartItem,
 
   REQUEST_COURSE,
@@ -31,9 +34,6 @@ import {
   RECEIVE_COURSE_LIST_FAILURE,
   SHOW_LOGIN,
   HIDE_LOGIN,
-  CLEAR_AUTHENTICATION_ERROR,
-  CLEAR_REGISTRATION_ERROR,
-  SHOW_SNACKBAR,
   HIDE_SNACKBAR,
   CHECKOUT_SUCCESS,
   CHECKOUT_FAILURE,
@@ -42,7 +42,6 @@ import {
   LOGIN_SUCCESS,
   LOGIN_FAILURE,
   LOGOUT,
-  CLEAR_COURSE,
   REGISTER_SUCCESS,
   REGISTER_FAILURE,
   ACTIVATE_SUCCESS,
@@ -59,7 +58,7 @@ import {
   FETCH_SUCCESS,
 } from '../actions/index_page';
 import * as api from '../util/api';
-import { COURSE_RESPONSE1 } from '../constants';
+import { COURSE_RESPONSE1, COURSE_LIST } from '../constants';
 
 import configureTestStore from '../store/configureStore_test';
 import assert from 'assert';
@@ -171,7 +170,7 @@ describe('reducers', () => {
     });
 
     it('should set login state to hide when triggered', done => {
-      dispatchThen(hideLogin(), [HIDE_LOGIN, CLEAR_AUTHENTICATION_ERROR, CLEAR_REGISTRATION_ERROR]).then(state => {
+      dispatchThen(hideLogin(), [HIDE_LOGIN]).then(state => {
         assert.deepEqual(state, {
           visible: false
         });
@@ -196,43 +195,10 @@ describe('reducers', () => {
       });
     });
 
-    it('should set snackBar to open when triggered', done => {
-      dispatchThen(
-        showSnackBar({ message: "Snackbar is open for business!" }),
-        [SHOW_SNACKBAR]
-      ).then(state => {
-        assert.deepEqual(state, {
-          message: "Snackbar is open for business!",
-          open: true
-        });
-        done();
-      });
-    });
-
-    it('should set snackbar open to false when triggered', done => {
-      let message = "Snackbar is open for business!";
-      dispatchThen(
-        showSnackBar({ message: message }),
-        [SHOW_SNACKBAR]
-      ).then(state => {
-        assert.deepEqual(state, {
-          message: message,
-          open: true
-        });
-
-        dispatchThen(hideSnackBar(), [HIDE_SNACKBAR]).then(state => {
-          assert.deepEqual(state, {
-            message: message,
-            open: false
-          });
-          done();
-        });
-      });
-    });
-
     it('messages the snackbar on checkout success', done => {
       dispatchThen(checkoutSuccess(), [CHECKOUT_SUCCESS]).then(state => {
         assert.equal(state.message, "Course successfully purchased!");
+        assert.ok(state.open);
         done();
       });
     });
@@ -240,8 +206,54 @@ describe('reducers', () => {
     it('messages the snackbar on checkout failure', done => {
       dispatchThen(checkoutFailure(), [CHECKOUT_FAILURE]).then(state => {
         assert.equal(state.message, "There was an error purchasing the course.");
+        assert.ok(state.open);
         done();
       });
+    });
+
+    it('shows a success message after registration', done => {
+      dispatchThen(registerSuccess(), [REGISTER_SUCCESS]).then(state => {
+        assert.equal(
+          state.message,
+          "User registered successfully! Check your email for an activation link."
+        );
+        assert.ok(state.open);
+        done();
+      });
+    });
+
+    it('shows a failure message after registration', done => {
+      dispatchThen(registerFailure(), [REGISTER_FAILURE]).then(state => {
+        assert.equal(
+          state.message,
+          "An error occurred registering the user."
+        );
+        assert.ok(state.open);
+        done();
+      });
+    });
+
+    it('shows an error after failing to load the course', done => {
+      dispatchThen(receiveCourseFailure(), [RECEIVE_COURSE_FAILURE]).then(state => {
+        assert.equal(
+          state.message,
+          "An error occurred fetching information about this course."
+        );
+        assert.ok(state.open);
+        done();
+      });
+    });
+
+    it('shows an error after failing to load the course list', done => {
+      dispatchThen(receiveCourseListFailure(), [RECEIVE_COURSE_LIST_FAILURE]).then(state => {
+        assert.equal(
+          state.message,
+          "An error occurred fetching information about other courses."
+        );
+        assert.ok(state.open);
+        done();
+      });
+
     });
   });
 
@@ -292,14 +304,14 @@ describe('reducers', () => {
       loginStub.returns(Promise.resolve({name: "Darth Vader"}));
 
       // ERROR
-      dispatchThen(login("user", "pass"), [LOGIN_SUCCESS, CLEAR_COURSE]).then(loginState => {
+      dispatchThen(login("user", "pass"), [LOGIN_SUCCESS]).then(loginState => {
         assert.deepEqual(loginState, {
           isAuthenticated: true,
           error: "",
           name: "Darth Vader"
         });
 
-        dispatchThen(logout(), [LOGOUT, CLEAR_COURSE]).then(logoutState => {
+        dispatchThen(logout(), [LOGOUT]).then(logoutState => {
           assert.deepEqual(logoutState, {
             isAuthenticated: false,
             error: "",
@@ -337,7 +349,7 @@ describe('reducers', () => {
         name: "Darth Vader"
       };
 
-      dispatchThen(login("user", "pass"), [LOGIN_SUCCESS, CLEAR_COURSE]).then(loginState => {
+      dispatchThen(login("user", "pass"), [LOGIN_SUCCESS]).then(loginState => {
         assert.deepEqual(loginState, expectedState);
 
         return dispatchThen(logout(), []);


### PR DESCRIPTION
#### What are the relevant tickets?

Fixes #400
#### What's this PR do?

The cause of the issue is that we show a message but we don't clear whatever piece of state caused the message to show up in the first place. There are three places we use snackbars currently: registration success/failure, course load success/failure, and checkout success/failure. So currently our messages are dispatched repeatedly, but silenced due to code to check for repeats. The registration snackbar message is dispatched whenever the App component is updated. I think the checkout message is dispatched right before the registration message and so you see the old registration message instead of anything else.

There's also some minor actions cleanup which shouldn't affect behavior.
#### Where should the reviewer start?

App.js and CourseDetailPage.js
#### How should this be manually tested?

Without refreshing or closing the browser:
- register a new user
- click the activation link. This should open a new tab
- go back to the old tab and login your user
- buy a course. The checkout success (or failure) message will be a registration success message instead
#### What GIF best describes this PR or how it makes you feel?

![](http://i.giphy.com/gx656616VR5ew.gif)
