### PR TITLE
Fixed buy tab to clear on unmount

### DIFF
--- a/static/js/containers/BuyTabContainer.js
+++ b/static/js/containers/BuyTabContainer.js
@@ -3,6 +3,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import BuyTab from '../components/BuyTab';
 import {
+  resetBuyTab,
   updateCartItems,
   updateCartVisibility,
   updateSelectedChapters,
@@ -35,6 +36,11 @@ class BuyTabContainer extends React.Component {
       checkout={this.onCheckout.bind(this)}
 
       />;
+  }
+
+  componentWillUnmount() {
+    const { dispatch } = this.props;
+    dispatch(resetBuyTab());
   }
 
   updateTotal() {

--- a/static/js/reducers/index_test.js
+++ b/static/js/reducers/index_test.js
@@ -25,6 +25,7 @@ import {
   registerSuccess,
   registerFailure,
   removeCartItem,
+  resetBuyTab,
 
   REQUEST_COURSE,
   RECEIVE_COURSE_SUCCESS,
@@ -648,8 +649,8 @@ describe('reducers', () => {
 
     it('sets cart visibility', done => {
       assert.equal(store.getState().buyTab.cartVisibility, false);
-      dispatchThen(updateCartVisibility(true), [UPDATE_CART_VISIBILITY]).then(cartState => {
-        assert.equal(cartState.cartVisibility, true);
+      dispatchThen(updateCartVisibility(true), [UPDATE_CART_VISIBILITY]).then(buyTabState => {
+        assert.equal(buyTabState.cartVisibility, true);
         done();
       });
     });
@@ -661,23 +662,28 @@ describe('reducers', () => {
       dispatchThen(
         updateSelectedChapters(['a', 'b', 'c'], true),
         [UPDATE_SELECTED_CHAPTERS]
-      ).then(cartState => {
-        assert.deepEqual(cartState.selectedChapters, ['a', 'b', 'c']);
-        assert.equal(cartState.allRowsSelected, true);
+      ).then(buyTabState => {
+        assert.deepEqual(buyTabState.selectedChapters, ['a', 'b', 'c']);
+        assert.equal(buyTabState.allRowsSelected, true);
 
         done();
       });
     });
 
-    it('updates seat count', done => {
+    it('updates seat count then resets it', done => {
       assert.equal(store.getState().buyTab.seats, 20);
 
       dispatchThen(
         updateSeatCount(200),
         [UPDATE_SEAT_COUNT]
-      ).then(cartState => {
-        assert.equal(cartState.seats, 200);
-        done();
+      ).then(buyTabState => {
+        assert.equal(buyTabState.seats, 200);
+
+        dispatchThen(resetBuyTab(), [RESET_BUYTAB]).then(buyTabState => {
+          assert.equal(buyTabState.seats, 20);
+
+          done();
+        });
       });
     });
   });


### PR DESCRIPTION
#### What are the relevant tickets?

Fixes #424
Rebased on #432 
#### What's this PR do?

Clears buy tab on unmount, and does some cleanup/fixes for broken tests
#### How should this be manually tested?

Go to the buy tab, select some chapters and move the seats slider. Then click on the course list link on the upper left. Click on the course again and look at the buy tab. You should see no chapters selected and 20 seats (the default).
