### PR TITLE
Skip webpack build step for development

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,7 @@ web:
     - .:/src
   environment:
     DEBUG: 'True'
+    NODE_ENV: 'development'
     PORT: 8075
     DATABASE_URL: postgres://postgres@db:5432/postgres
     PORTAL_DB_DISABLE_SSL: 'True'
@@ -40,3 +41,6 @@ watch:
     - "8076:8076"
   volumes:
     - .:/src
+  environment:
+    NODE_ENV: 'development'
+

--- a/package.json
+++ b/package.json
@@ -55,6 +55,6 @@
     "webpack-stats-plugin": "^0.1.1"
   },
   "scripts": {
-    "postinstall": "node node_modules/webpack/bin/webpack.js --config webpack.config.prod.js"
+    "postinstall": "./webpack_if_prod.sh"
   }
 }

--- a/tox.ini
+++ b/tox.ini
@@ -19,6 +19,8 @@ commands =
     npm install --no-bin-links --prefix {toxinidir}
     node {toxinidir}/node_modules/eslint/bin/eslint.js {toxinidir}/static/js
     node {toxinidir}/node_modules/mocha/bin/mocha {posargs} --opts static/js/mocha.opts static/js/global_init.js "static/**/*_test.js"
+setenv =
+    NODE_ENV=development
 
 whitelist_externals =
     npm

--- a/travis-docker-compose.yml
+++ b/travis-docker-compose.yml
@@ -11,6 +11,7 @@ web:
     ./with_host.sh python manage.py runserver 0.0.0.0:8075'
   environment:
     DEBUG: 'False'
+    NODE_ENV: 'production'
     PORT: 8075
     DATABASE_URL: postgres://postgres@db:5432/postgres
     PORTAL_DB_DISABLE_SSL: 'True'

--- a/webpack_if_prod.sh
+++ b/webpack_if_prod.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -euf -o pipefail
+if [[ "$NODE_ENV" != "development" ]]
+then
+    node node_modules/webpack/bin/webpack.js --config webpack.config.prod.js
+fi


### PR DESCRIPTION
#### What are the relevant tickets?

Fixes #435
#### What's this PR do?

Adds NODE_ENV environment variable to tell between development and production, and adds a script which uses it to run npm install only on production builds.
#### How should this be manually tested?

`docker-compose up` should still work as before, and tests should still run fine. I'm not sure if we have a PR heroku environment set up for teachersportal but if so it would allow us to make sure nothing has changed in production.
