### PR TITLE
Added fields to Course, change course API to not contact CCXCon anymore

### DIFF
--- a/portal/factories.py
+++ b/portal/factories.py
@@ -53,6 +53,7 @@ class CourseFactory(DjangoModelFactory):
     description = factory.LazyAttribute(lambda x: FAKE.text())
     live = False
     instance = factory.SubFactory(BackingInstanceFactory)
+    instructors = factory.LazyAttribute(lambda x: [FAKE.text() for _ in range(10)])
 
     class Meta:  # pylint: disable=missing-docstring,no-init,too-few-public-methods,old-style-class
         model = Course

--- a/portal/migrations/0010_add_course_fields.py
+++ b/portal/migrations/0010_add_course_fields.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import jsonfield.fields
+
+# pylint: skip-file
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('portal', '0009_no_null_for_description'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='course',
+            name='author_name',
+            field=models.TextField(null=True, blank=True),
+        ),
+        migrations.AddField(
+            model_name='course',
+            name='course_id',
+            field=models.TextField(null=True, blank=True),
+        ),
+        migrations.AddField(
+            model_name='course',
+            name='image_url',
+            field=models.TextField(null=True, blank=True),
+        ),
+        migrations.AddField(
+            model_name='course',
+            name='instructors',
+            field=jsonfield.fields.JSONField(null=True, blank=True),
+        ),
+        migrations.AddField(
+            model_name='course',
+            name='overview',
+            field=models.TextField(null=True, blank=True),
+        ),
+        migrations.AlterField(
+            model_name='course',
+            name='description',
+            field=models.TextField(null=True, blank=True),
+        ),
+        migrations.AlterField(
+            model_name='module',
+            name='course',
+            field=models.ForeignKey(related_name='modules', to='portal.Course'),
+        ),
+    ]

--- a/portal/models.py
+++ b/portal/models.py
@@ -19,6 +19,7 @@ from django.db.models.fields import (
     DateTimeField,
 )
 from django.utils.encoding import python_2_unicode_compatible
+from jsonfield import JSONField
 
 from portal.permissions import (
     EDIT_OWN_CONTENT,
@@ -47,21 +48,26 @@ class Course(models.Model):
     """
     uuid = TextField()
     title = TextField()
-    description = TextField(blank=True)
+    description = TextField(blank=True, null=True)
     live = BooleanField()
     created_at = DateTimeField(auto_now_add=True, blank=True)
     modified_at = DateTimeField(auto_now=True, blank=True)
     instance = ForeignKey(BackingInstance)
     owners = ManyToManyField(to=User, related_name="courses_owned", blank=True)
+    course_id = TextField(blank=True, null=True)
+    author_name = TextField(blank=True, null=True)
+    overview = TextField(blank=True, null=True)
+    image_url = TextField(blank=True, null=True)
+    instructors = JSONField(blank=True, null=True)
 
     @property
     def is_available_for_purchase(self):
         """
         Does the course have any modules available for purchase?
         """
-        if self.module_set.count() == 0:
+        if self.modules.count() == 0:
             return False
-        return all(module.is_available_for_purchase for module in self.module_set.all())
+        return all(module.is_available_for_purchase for module in self.modules.all())
 
     def __str__(self):
         """String representation to show in Django Admin console"""
@@ -82,7 +88,7 @@ class Module(models.Model):
     A chapter in a CCX course
     """
     uuid = TextField()
-    course = ForeignKey(Course)
+    course = ForeignKey(Course, related_name="modules")
     title = TextField()
     price_without_tax = DecimalField(decimal_places=2, max_digits=20, blank=True, null=True)
     created_at = DateTimeField(auto_now_add=True, blank=True)

--- a/portal/serializers.py
+++ b/portal/serializers.py
@@ -5,32 +5,64 @@ Serializers for REST API
 from __future__ import unicode_literals
 
 from rest_framework.serializers import (
-    Serializer,
-    BooleanField,
-    CharField,
-    DictField,
-    ListField,
+    FloatField,
+    ModelSerializer,
+    SerializerMethodField,
+    StringRelatedField,
 )
 
+from portal.models import Course, Module
 
-# pylint: disable=abstract-method
-class CourseSerializer(Serializer):
+
+# pylint: disable=abstract-method,no-init,old-style-class
+class ModuleSerializer(ModelSerializer):
+    """Serializer for Module"""
+    # price_without_tax is a Decimal which renders to a string by default
+    price_without_tax = FloatField()
+
+    class Meta:  # pylint: disable=missing-docstring, too-few-public-methods
+        model = Module
+        fields = ('uuid', 'title', 'price_without_tax')
+
+
+class CourseSerializer(ModelSerializer):
     """Serializer for Course"""
 
-    title = CharField()
-    description = CharField()
-    uuid = CharField()
-    info = DictField()
-    live = BooleanField()
-    modules = ListField()
+    modules = ModuleSerializer(many=True, read_only=True)
+    edx_instance = StringRelatedField(source="instance")
+    instructors = SerializerMethodField()
+
+    class Meta:  # pylint: disable=missing-docstring, too-few-public-methods
+        model = Course
+        fields = (
+            'title',
+            'description',
+            'uuid',
+            'live',
+            'modules',
+            'course_id',
+            'author_name',
+            'overview',
+            'image_url',
+            'instructors',
+            'edx_instance',
+        )
+
+    def get_instructors(self, obj):  # pylint: disable=no-self-use
+        """Output the instructor JSON without escaping it"""
+        return obj.instructors
 
 
-class CourseSerializerReduced(Serializer):
+class CourseSerializerReduced(ModelSerializer):
     """
     Serializer for Course with reduced information
     """
 
-    title = CharField()
-    description = CharField()
-    info = DictField()
-    uuid = CharField()
+    class Meta:  # pylint: disable=missing-docstring, too-few-public-methods
+        model = Course
+        fields = (
+            'title',
+            'description',
+            'uuid',
+            'image_url',
+        )

--- a/portal/serializers_test.py
+++ b/portal/serializers_test.py
@@ -1,0 +1,58 @@
+"""Tests for serializers"""
+from __future__ import unicode_literals
+
+from django.test import TestCase
+
+from portal.factories import CourseFactory, ModuleFactory
+from portal.serializers import (
+    CourseSerializer,
+    CourseSerializerReduced,
+    ModuleSerializer,
+)
+
+
+class SerializersTest(TestCase):
+    """
+    Tests for serializers
+    """
+
+    def test_course_reduced_serializer(self):  # pylint: disable=no-self-use
+        """Assert behavior of CourseSerializerReduced"""
+        course = CourseFactory.create()
+        assert dict(CourseSerializerReduced().to_representation(course)) == {
+            "uuid": course.uuid,
+            "title": course.title,
+            "description": course.description,
+            "image_url": course.image_url,
+        }
+
+    def test_course_serializer(self):  # pylint: disable=no-self-use
+        """Assert behavior of CourseSerializer"""
+        course = CourseFactory.create()
+        module = ModuleFactory.create(course=course)
+        rep = CourseSerializer(course).data
+        assert isinstance(rep['instructors'], list)
+        assert dict(rep) == {
+            "uuid": course.uuid,
+            "title": course.title,
+            "author_name": course.author_name,
+            "overview": course.overview,
+            "description": course.description,
+            "image_url": course.image_url,
+            "edx_instance": course.instance.instance_url,
+            "instructors": course.instructors,
+            "course_id": course.course_id,
+            "live": course.live,
+            "modules": [
+                ModuleSerializer().to_representation(module)
+            ]
+        }
+
+    def test_module_serializer(self):  # pylint: disable=no-self-use
+        """Assert behavior of ModuleSerializer"""
+        module = ModuleFactory.create()
+        assert dict(ModuleSerializer().to_representation(module)) == {
+            "uuid": module.uuid,
+            "title": module.title,
+            "price_without_tax": float(module.price_without_tax)
+        }

--- a/portal/util.py
+++ b/portal/util.py
@@ -18,55 +18,6 @@ from portal.permissions import AuthorizationHelpers
 log = logging.getLogger(__name__)
 
 
-def course_as_dict(course, course_info=None, modules_info=None):
-    """
-    Serialize course to dict, ready for JSON serialization
-    Args:
-        course (Course): A Course
-        course_info (dict): Information fetched from CCXCon about the course
-        modules_info (dict): Information about each module, in fetched order
-
-    Returns:
-        dict: The course as a dictionary
-    """
-    if modules_info is None:
-        modules_info = {}
-
-    modules = [
-        module_as_dict(module, modules_info.get(module.uuid))
-        for module in course.module_set.order_by('created_at')
-        ]
-    return {
-        "title": course.title,
-        "description": course.description,
-        "uuid": course.uuid,
-        "info": course_info,
-        "modules": modules,
-        "live": course.live
-    }
-
-
-def module_as_dict(module, ccxcon_module_info=None):
-    """
-    Serialize module to dict, ready for JSON serialization
-    Args:
-        module (Module): A Module
-        ccxcon_module_info (dict): Information fetched from CCXCon
-
-    Returns:
-        dict: The module as a dictionary
-    """
-    price_without_tax = None
-    if module.price_without_tax is not None:
-        price_without_tax = float(module.price_without_tax)
-    return {
-        "title": module.title,
-        "uuid": module.uuid,
-        "price_without_tax": price_without_tax,
-        "info": ccxcon_module_info,
-    }
-
-
 def calculate_cart_subtotal(cart):
     """
     Calculate total of a cart.

--- a/portal/util_test.py
+++ b/portal/util_test.py
@@ -19,8 +19,6 @@ from portal.util import (
     calculate_orderline_total,
     create_order,
     get_cents,
-    course_as_dict,
-    module_as_dict,
     validate_cart,
 )
 
@@ -29,37 +27,6 @@ class CourseUtilTests(CourseTests):
     """
     Test for utility functions.
     """
-
-    def test_course_module_json(self):
-        """
-        Test functionality of course_as_json and module_as_json
-        """
-
-        expected_module = {
-            "title": self.module.title,
-            "uuid": self.module.uuid,
-            "price_without_tax": float(self.module.price_without_tax),
-            "info": {
-                "type": "module"
-            }
-        }
-        course_info = {"type": "course"}
-        modules_info = {
-            self.module.uuid: {
-                "type": "module"
-            }
-        }
-        assert module_as_dict(self.module, modules_info[self.module.uuid]) == expected_module
-        assert course_as_dict(self.course, course_info, modules_info) == {
-            "title": self.course.title,
-            "description": self.course.description,
-            "uuid": self.course.uuid,
-            "info": {
-                "type": "course"
-            },
-            "modules": [expected_module],
-            "live": self.course.live
-        }
 
     def test_live_availability(self):
         """Assert that live boolean affects availability for purchase"""

--- a/portal/views/course_api.py
+++ b/portal/views/course_api.py
@@ -5,11 +5,9 @@ from __future__ import unicode_literals
 
 from decimal import Decimal, DecimalException
 import logging
-import json
 from six.moves.urllib.parse import (  # pylint: disable=import-error
     urlparse,
     urlunparse,
-    urljoin,
 )
 from six import string_types
 
@@ -20,16 +18,12 @@ from requests_oauthlib import OAuth2Session
 from rest_framework.exceptions import ValidationError
 from rest_framework.generics import ListAPIView, RetrieveAPIView
 from rest_framework.response import Response
-from rest_framework.status import HTTP_200_OK
 
 from portal.models import Module
 from portal.permissions import AuthorizationHelpers
 from portal.serializers import (
     CourseSerializer,
     CourseSerializerReduced,
-)
-from portal.util import (
-    course_as_dict,
 )
 
 
@@ -62,98 +56,6 @@ def ccxcon_request():
     return oauth_ccxcon
 
 
-def filter_ccxcon_course_info(course_info):
-    """
-    Filter course info
-    Args:
-        course_info (dict): CCXCon course info
-
-    Returns:
-        The CCXCon course info with only allowed fields
-    """
-    allowed_course_keys = ('title', 'description', 'overview', 'image_url', 'author_name')
-    return {
-        k: v for k, v in course_info.items()
-        if k in allowed_course_keys
-    }
-
-
-def filter_ccxcon_module_info(module_info):
-    """
-    Filter module info
-
-    Args:
-        module_info (dict): CCXCon module info
-
-    Returns:
-        The CCXCon module info with only allowed fields
-    """
-    allowed_module_keys = ('title', 'subchapters')
-    return {
-        k: v for k, v in module_info.items()
-        if k in allowed_module_keys
-    }
-
-
-def fetch_ccxcon_info(uuid):
-    """
-    Fetch information from CCXCon about a course and its modules. Note that
-    this list is not filtered by availability to buy, that will be done in view.
-    Args:
-        uuid (str): The course uuid
-    Returns:
-        tuple:
-            (dict, dict) where
-            Item one is information from CCXCon for a course,
-            Item two is the information for each module for that course
-    """
-    oauth_ccxcon = ccxcon_request()
-
-    course_url = urljoin(
-        settings.CCXCON_API,
-        'v1/coursexs/{course_uuid}/'.format(course_uuid=uuid)
-    )
-    response = oauth_ccxcon.get(course_url)
-    if response.status_code != HTTP_200_OK:
-        log.info(
-            "Unable to fetch course from CCXCon: url: %s, code: %s, content: %s",
-            course_url,
-            response.status_code,
-            response.content.decode('utf-8')
-        )
-        raise Exception("CCXCon returned a non 200 status code {code}: {content}".format(
-            code=response.status_code,
-            content=response.content,
-        ))
-    course_info = json.loads(response.content.decode('utf-8'))
-    # Whitelist of allowed keys to pass through
-
-    # Add module information to list
-    modules_url = urljoin(
-        settings.CCXCON_API,
-        'v1/coursexs/{course_uuid}/modules/'.format(course_uuid=uuid)
-    )
-    response = oauth_ccxcon.get(modules_url)
-    if response.status_code != HTTP_200_OK:
-        log.info(
-            "Unable to fetch modules from CCXCon: url: %s, code: %s, content: %s",
-            modules_url,
-            response.status_code,
-            response.content.decode('utf-8')
-        )
-        raise Exception("CCXCon returned a non 200 status code {code}: {content}".format(
-            code=response.status_code,
-            content=response.content,
-        ))
-    data = json.loads(response.content.decode('utf-8'))
-    modules_info = {}
-    for module_info in data:
-        uuid = module_info['uuid']
-        modules_info[uuid] = module_info
-
-    return course_info, modules_info
-
-
 class CourseListView(ListAPIView):
     """
     Lists courses available for purchase
@@ -165,10 +67,7 @@ class CourseListView(ListAPIView):
     def get_queryset(self):
         """A queryset for courses that are available for purchase"""
 
-        return [
-            course_as_dict(course)
-            for course in AuthorizationHelpers.get_courses(self.request.user)
-        ]
+        return AuthorizationHelpers.get_courses(self.request.user)
 
 
 class CourseDetailView(RetrieveAPIView):
@@ -196,16 +95,7 @@ class CourseDetailView(RetrieveAPIView):
         if course is None:
             raise Http404
 
-        course_info, modules_info = fetch_ccxcon_info(uuid)
-
-        return course_as_dict(
-            course,
-            filter_ccxcon_course_info(course_info),
-            {
-                uuid: filter_ccxcon_module_info(module)
-                for uuid, module in modules_info.items()
-            }
-        )
+        return course
 
     # This method is a mammoth due to how much per-field validation we need to do
     # pylint: disable=too-many-locals, too-many-branches, too-many-statements

--- a/portal/views/webhooks_test.py
+++ b/portal/views/webhooks_test.py
@@ -55,7 +55,13 @@ class WebhookTests(TestCase):
             'payload': {
                 'title': self.COURSE_TITLE1,
                 'external_pk': self.COURSE_UUID1,
-                'instance': self.INSTANCE
+                'instance': self.INSTANCE,
+                'course_id': 'course_id',
+                'author_name': 'author_name',
+                'overview': 'overview',
+                'description': 'description',
+                'image_url': 'image_url',
+                'instructors': ['one', 'two', 'three'],
             }
         })
         self.post_webhook({
@@ -136,7 +142,13 @@ class WebhookTests(TestCase):
             'payload': {
                 'title': self.COURSE_TITLE2,
                 'external_pk': self.COURSE_UUID2,
-                'instance': self.INSTANCE
+                'instance': self.INSTANCE,
+                'course_id': 'course_id',
+                'author_name': 'author_name',
+                'overview': 'overview',
+                'description': 'description',
+                'image_url': 'image_url',
+                'instructors': ['one', 'two', 'three'],
             }
         }
         resp = self.client.post(
@@ -158,7 +170,13 @@ class WebhookTests(TestCase):
             'payload': {
                 'title': self.COURSE_TITLE2,
                 'external_pk': self.COURSE_UUID2,
-                'instance': self.INSTANCE
+                'instance': self.INSTANCE,
+                'course_id': 'course_id',
+                'author_name': 'author_name',
+                'overview': 'overview',
+                'description': 'description',
+                'image_url': 'image_url',
+                'instructors': ['one', 'two', 'three'],
             }
         }
         # Signature is now for a different set of data and therefore invalid
@@ -185,15 +203,28 @@ class WebhookTests(TestCase):
             'payload': {
                 'title': self.COURSE_TITLE2,
                 'external_pk': self.COURSE_UUID2,
-                'instance': self.INSTANCE
+                'instance': self.INSTANCE,
+                'course_id': 'course_id',
+                'author_name': 'author_name',
+                'overview': 'overview',
+                'description': 'description',
+                'image_url': 'image_url',
+                'instructors': ['one', 'two', 'three'],
             }
         })
 
         courses = self.get_courses()
         assert len(courses) == course_count + 1
-        assert courses[-1].title == self.COURSE_TITLE2
-        assert courses[-1].uuid == self.COURSE_UUID2
-        assert courses[-1].instance.instance_url == self.INSTANCE
+        course = courses[-1]
+        assert course.title == self.COURSE_TITLE2
+        assert course.uuid == self.COURSE_UUID2
+        assert course.instance.instance_url == self.INSTANCE
+        assert course.course_id == 'course_id'
+        assert course.author_name == 'author_name'
+        assert course.overview == 'overview'
+        assert course.description == 'description'
+        assert course.image_url == 'image_url'
+        assert course.instructors == ['one', 'two', 'three']
 
     def test_update_course(self):
         """
@@ -208,15 +239,64 @@ class WebhookTests(TestCase):
             'payload': {
                 'title': new_title,
                 'external_pk': self.COURSE_UUID1,
-                'instance': self.INSTANCE
+                'instance': self.INSTANCE,
+                'course_id': 'new course_id',
+                'author_name': 'new author_name',
+                'overview': 'new overview',
+                'description': 'new description',
+                'image_url': 'new image_url',
+                'instructors': ['four'],
             }
         })
 
         courses = self.get_courses()
         assert len(courses) == course_count
-        assert courses[0].title == new_title
-        assert courses[0].uuid == self.COURSE_UUID1
-        assert courses[0].instance.instance_url == self.INSTANCE
+        course = courses[0]
+        assert course.title == new_title
+        assert course.uuid == self.COURSE_UUID1
+        assert course.instance.instance_url == self.INSTANCE
+        assert course.course_id == 'new course_id'
+        assert course.author_name == 'new author_name'
+        assert course.overview == 'new overview'
+        assert course.description == 'new description'
+        assert course.image_url == 'new image_url'
+        assert course.instructors == ['four']
+
+    def test_update_course_null(self):
+        """
+        Test updating a course with null values.
+        """
+        course_count = len(self.get_courses())
+        # Second time it should update course in place.
+        new_title = "changed title"
+        self.post_webhook({
+            'action': 'update',
+            'type': COURSE_PRODUCT_TYPE,
+            'payload': {
+                'title': new_title,
+                'external_pk': self.COURSE_UUID1,
+                'instance': self.INSTANCE,
+                'course_id': None,
+                'author_name': None,
+                'overview': None,
+                'description': None,
+                'image_url': None,
+                'instructors': None,
+            }
+        })
+
+        courses = self.get_courses()
+        assert len(courses) == course_count
+        course = courses[0]
+        assert course.title == new_title
+        assert course.uuid == self.COURSE_UUID1
+        assert course.instance.instance_url == self.INSTANCE
+        assert course.course_id is None
+        assert course.author_name is None
+        assert course.overview is None
+        assert course.description is None
+        assert course.image_url is None
+        assert course.instructors is None
 
     def test_add_course_with_same_title(self):
         """Test adding a course with duplicate titles"""
@@ -228,7 +308,13 @@ class WebhookTests(TestCase):
             'payload': {
                 'title': self.COURSE_TITLE1,
                 'external_pk': self.COURSE_UUID2,
-                'instance': self.INSTANCE
+                'instance': self.INSTANCE,
+                'course_id': 'course_id',
+                'author_name': 'author_name',
+                'overview': 'overview',
+                'description': 'description',
+                'image_url': 'image_url',
+                'instructors': ['one', 'two', 'three'],
             }
         })
 
@@ -262,7 +348,13 @@ class WebhookTests(TestCase):
             'payload': {
                 'title': self.COURSE_TITLE1,
                 'external_pk': '',
-                'instance': self.INSTANCE
+                'instance': self.INSTANCE,
+                'course_id': 'course_id',
+                'author_name': 'author_name',
+                'overview': 'overview',
+                'description': 'description',
+                'image_url': 'image_url',
+                'instructors': ['one', 'two', 'three'],
             }
         }, expected_status=400, expected_errors=['Invalid external_pk'])
 
@@ -296,7 +388,13 @@ class WebhookTests(TestCase):
             'payload': {
                 'title': self.MODULE_TITLE1,
                 'external_pk': self.MODULE_UUID1,
-                'instance': self.INSTANCE
+                'instance': self.INSTANCE,
+                'course_id': 'course_id',
+                'author_name': 'author_name',
+                'overview': 'overview',
+                'description': 'description',
+                'image_url': 'image_url',
+                'instructors': ['one', 'two', 'three'],
             }
         })
 
@@ -317,7 +415,13 @@ class WebhookTests(TestCase):
             'payload': {
                 'title': '',
                 'external_pk': self.COURSE_UUID1,
-                'instance': self.INSTANCE
+                'instance': self.INSTANCE,
+                'course_id': 'course_id',
+                'author_name': 'author_name',
+                'overview': 'overview',
+                'description': 'description',
+                'image_url': 'image_url',
+                'instructors': ['one', 'two', 'three'],
             }
         })
 
@@ -519,7 +623,13 @@ class WebhookTests(TestCase):
             'payload': {
                 'title': self.COURSE_TITLE2,
                 'external_pk': self.COURSE_UUID2,
-                'instance': self.INSTANCE
+                'instance': self.INSTANCE,
+                'course_id': 'course_id',
+                'author_name': 'author_name',
+                'overview': 'overview',
+                'description': 'description',
+                'image_url': 'image_url',
+                'instructors': ['one', 'two', 'three'],
             }
         })
         courses = self.get_courses()
@@ -558,7 +668,13 @@ class WebhookTests(TestCase):
             'payload': {
                 'title': self.COURSE_TITLE2,
                 'external_pk': self.COURSE_UUID2,
-                'instance': self.INSTANCE
+                'instance': self.INSTANCE,
+                'course_id': 'course_id',
+                'author_name': 'author_name',
+                'overview': 'overview',
+                'description': 'description',
+                'image_url': 'image_url',
+                'instructors': ['one', 'two', 'three'],
             }
         })
         # Update module1 to point to course2
@@ -709,7 +825,13 @@ class WebhookTests(TestCase):
         payload = {
             'title': self.COURSE_TITLE1,
             'external_pk': self.COURSE_UUID1,
-            'instance': self.INSTANCE
+            'instance': self.INSTANCE,
+            'course_id': 'course_id',
+            'author_name': 'author_name',
+            'overview': 'overview',
+            'description': 'description',
+            'image_url': 'image_url',
+            'instructors': ['one', 'two', 'three'],
         }
         for key in payload.keys():
             payload_copy = dict(payload)
@@ -744,7 +866,13 @@ class WebhookTests(TestCase):
             'payload': {
                 'title': self.COURSE_TITLE1,
                 'external_pk': self.COURSE_UUID1,
-                'instance': '{}/update'.format(self.INSTANCE)
+                'instance': '{}/update'.format(self.INSTANCE),
+                'course_id': 'course_id',
+                'author_name': 'author_name',
+                'overview': 'overview',
+                'description': 'description',
+                'image_url': 'image_url',
+                'instructors': ['one', 'two', 'three'],
             }
         }, expected_status=400, expected_errors=['Instance cannot be changed'])
 
@@ -758,7 +886,13 @@ class WebhookTests(TestCase):
                     'payload': {
                         'title': self.COURSE_TITLE1,
                         'external_pk': self.COURSE_UUID1,
-                        'instance': instance
+                        'instance': instance,
+                        'course_id': 'course_id',
+                        'author_name': 'author_name',
+                        'overview': 'overview',
+                        'description': 'description',
+                        'image_url': 'image_url',
+                        'instructors': ['one', 'two', 'three'],
                     }
                 },
                 expected_status=400,

--- a/portal/webhooks.py
+++ b/portal/webhooks.py
@@ -29,6 +29,12 @@ def course(action, payload):
             title = payload['title']
             uuid = payload['external_pk']
             instance_url = payload['instance']
+            course_id = payload['course_id']
+            author_name = payload['author_name']
+            overview = payload['overview']
+            description = payload['description']
+            image_url = payload['image_url']
+            instructors = payload['instructors']
         except KeyError as ex:
             raise ValidationError("Missing key {key}".format(key=ex.args[0]))
         except TypeError as ex:
@@ -45,6 +51,13 @@ def course(action, payload):
                 if existing_course.instance.instance_url != instance_url:
                     raise ValidationError("Instance cannot be changed")
                 existing_course.title = title
+
+                existing_course.course_id = course_id
+                existing_course.author_name = author_name
+                existing_course.overview = overview
+                existing_course.description = description
+                existing_course.image_url = image_url
+                existing_course.instructors = instructors
                 existing_course.save()
             except Course.DoesNotExist:
                 backing_instance, _ = BackingInstance.objects.get_or_create(
@@ -54,14 +67,20 @@ def course(action, payload):
                     uuid=uuid,
                     title=title,
                     live=False,
-                    instance=backing_instance
+                    instance=backing_instance,
+                    course_id=course_id,
+                    author_name=author_name,
+                    overview=overview,
+                    description=description,
+                    image_url=image_url,
+                    instructors=instructors,
                 )
     elif action == 'delete':
         try:
             uuid = payload['external_pk']
         except KeyError as ex:
             raise ValidationError("Missing key {key}".format(key=ex.args[0]))
-        except TypeError as ex:
+        except TypeError:
             raise ValidationError("Invalid value for payload")
         Course.objects.filter(uuid=uuid).delete()
     else:
@@ -118,7 +137,7 @@ def module(action, payload):
             uuid = payload['external_pk']
         except KeyError as ex:
             raise ValidationError("Missing key {key}".format(key=ex.args[0]))
-        except TypeError as ex:
+        except TypeError:
             raise ValidationError("Invalid value for payload")
         with transaction.atomic():
             Module.objects.filter(uuid=uuid).delete()

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ requests-oauthlib==0.5.0
 newrelic==2.54.0.41
 stripe==1.27.1
 django-server-status==0.3
+jsonfield==1.0.3

--- a/static/js/components/CourseCard.js
+++ b/static/js/components/CourseCard.js
@@ -16,11 +16,10 @@ class CourseCard extends Component {
 
     let path = "/courses/" + course.uuid;
 
-    let ccxDescription = course.info ? course.info.description : "";
-    let description = course.description || ccxDescription;
+    let description = course.description;
 
     let content = <Card className="course-card">
-      <CourseCardImage src="http://lorempixel.com/305/75/abstract/" />
+      <CourseCardImage src={course.image_url} />
       <Link to={path}>
         <CardTitle
           title={course.title}

--- a/static/js/components/CourseDetail.js
+++ b/static/js/components/CourseDetail.js
@@ -23,13 +23,13 @@ class CourseDetail extends Component {
     let baseContent = <div>
       <CardTitle
         title={course.title}
-        subtitle={course.info.author_name}
+        subtitle={course.author_name}
         id="course-title"
       />
-      <CourseImage src={course.info.image_url}/>
+      <CourseImage src={course.image_url}/>
       <CardText
         id="course-description"
-        dangerouslySetInnerHTML={{__html: course.description || course.info.description }}
+        dangerouslySetInnerHTML={{__html: course.description }}
       />
     </div>;
 

--- a/static/js/components/CourseTabs.js
+++ b/static/js/components/CourseTabs.js
@@ -21,7 +21,7 @@ class CourseTabs extends React.Component {
     return <Card id="course-tabs-card">
         <Tabs id="course-tabs">
             <Tab label="About" id="about" className="tab" onActive={this.handleActive}>
-                <AboutTab content={course.info.overview} />
+                <AboutTab content={course.overview} />
             </Tab>
             <Tab label="Buy" id="buy" className="tab" onActive={this.handleActive}>
                 <BuyTabContainer


### PR DESCRIPTION
#### What are the relevant tickets?

Fixes #437 
Fixes #425 
#### What's this PR do?
- Adds fields to Course which are populated by new fields in the webhooks
- Removes code to contact CCXCon in the course API
- Updates the front end to account for the moved fields
- Adds `CourseSerializer` and `ModuleSerializer` to replace `course_as_dict` and `module_as_dict`
#### Where should the reviewer start?

portal/models.py
#### How should this be manually tested?

First, make sure you have the latest master from CCXCon. Adjust the Advanced Settings in your devstack to cause the webhook to execute. Then view the course listing and course detail page for a course. The course listing and course detail page should look exactly the same as before. You should test this while logged in and logged out.
#### Background context

Some of the validation done for course PATCH is unnecessary now but I'd like to push that off until another PR sometime in the future to prevent this one from blowing up.
#### What GIF best describes this PR or how it makes you feel?

![](http://i.imgur.com/v5peAgO.gif)
