### PR TITLE
Bump django-server-status to 0.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,4 +12,4 @@ django-oauth-toolkit==0.9.0
 requests-oauthlib==0.5.0
 newrelic==2.54.0.41
 stripe==1.27.1
-django-server-status==0.1.1
+django-server-status==0.3


### PR DESCRIPTION
#### What are the relevant tickets?

https://github.com/mitodl/django-server-status/issues/17
#### What's this PR do?

This will allow for more reliable availability checks from NewRelic: https://github.com/mitodl/django-server-status/pull/19
#### How should this be manually tested?

Just check the output of the `/status` URL exposed by the django-server-status app. If it contains the `status_all` property, it works.

Note: This can only be reviewed once 0.3 is merged and the new package is pushed to pypi.
